### PR TITLE
Post-repository-migration updates.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,16 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  CODEBUILD_EXECUTOR_IAM_ROLE: "arn:aws:iam::500609504579:role/github-build-runner"
+  CODEBUILD_EXECUTOR_SESSION_NAME: "github-build-runner"
+  CODEBUILD_PROJECT_NAME: "build-only"
+  AWS_REGION: "us-west-2"
+
+permissions:
+  id-token: write
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -23,16 +33,16 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          role-to-assume: ${{ env.CODEBUILD_EXECUTOR_IAM_ROLE }}
+          role-session-name: ${{ env.CODEBUILD_EXECUTOR_SESSION_NAME }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1.0.3
         with:
-          project-name: flux-builds
+          project-name: ${{ env.CODEBUILD_PROJECT_NAME }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Flux is a Java client library for SWF. This document provides basic code samples
 
 Flux is in production use by multiple public AWS services.
 
-![CodeBuild status badge](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZ2ZyUXlPTEpyeXNiZVVOc2FqOUZCdlBXMytKZE5wbXNCZGtIOWp4ODBUYWhTWjI2RmFETWpLT0ZCc1Jnd0tzaUtwT1NoSWwwVjlXanM1OUUrcitoQlg0PSIsIml2UGFyYW1ldGVyU3BlYyI6InVKZTBIQ2s2UHpPT3lrNTYiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
+![CodeBuild status badge](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiSlhGMTFDV3dRRXJCdUxSYzdLQ3R0QzZ2WjArSWN2ZkZtVFhUbzB3L2FUZnJBZDhMbzFXQzI1WkpRRWUzdkgvcko4MFJoc1RHRW5BVmJZc3dMeWRQKzlvPSIsIml2UGFyYW1ldGVyU3BlYyI6IjcxN0ZlaXI0M3ZPdXVabDciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 Flux quick start guide
 ======================

--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>software.amazon.aws.clients.swf.flux</groupId>
+        <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
         <version>2.0.7</version>
     </parent>
     <artifactId>flux-common</artifactId>
     <name>Flux SWF Client Common</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
-    <url>https://github.com/awslabs/flux-swf-client</url>
+    <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://aws.amazon.com/apache2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/flux-guice/pom.xml
+++ b/flux-guice/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>software.amazon.aws.clients.swf.flux</groupId>
+        <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
         <version>2.0.7</version>
     </parent>
     <artifactId>flux-guice</artifactId>
     <name>Flux SWF Client Guice Helper</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
-    <url>https://github.com/awslabs/flux-swf-client</url>
+    <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://aws.amazon.com/apache2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -34,7 +34,7 @@
         <!-- flux internal dependencies -->
         <dependency>
             <artifactId>flux</artifactId>
-            <groupId>software.amazon.aws.clients.swf.flux</groupId>
+            <groupId>com.danielgmyers.flux.clients.swf</groupId>
             <version>${flux.version}</version>
             <optional>false</optional>
         </dependency>

--- a/flux-integration-tests/pom.xml
+++ b/flux-integration-tests/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>software.amazon.aws.clients.swf.flux</groupId>
+        <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
         <version>2.0.7</version>
     </parent>
     <artifactId>flux-integration-tests</artifactId>
     <name>Flux SWF Client integration tests</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
-    <url>https://github.com/awslabs/flux-swf-client</url>
+    <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://aws.amazon.com/apache2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -23,7 +23,7 @@
 
         <dependency>
             <artifactId>flux</artifactId>
-            <groupId>software.amazon.aws.clients.swf.flux</groupId>
+            <groupId>com.danielgmyers.flux.clients.swf</groupId>
             <version>${flux.version}</version>
             <optional>false</optional>
         </dependency>

--- a/flux-spring/pom.xml
+++ b/flux-spring/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>software.amazon.aws.clients.swf.flux</groupId>
+        <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
         <version>2.0.7</version>
     </parent>
     <artifactId>flux-spring</artifactId>
     <name>Flux SWF Client Spring Helper</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
-    <url>https://github.com/awslabs/flux-swf-client</url>
+    <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://aws.amazon.com/apache2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -29,7 +29,7 @@
         <!-- flux internal dependencies -->
         <dependency>
             <artifactId>flux</artifactId>
-            <groupId>software.amazon.aws.clients.swf.flux</groupId>
+            <groupId>com.danielgmyers.flux.clients.swf</groupId>
             <version>${flux.version}</version>
             <optional>false</optional>
         </dependency>

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>software.amazon.aws.clients.swf.flux</groupId>
+        <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
         <version>2.0.7</version>
     </parent>
     <artifactId>flux-testutils</artifactId>
     <name>Flux SWF Client Test Utils</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
-    <url>https://github.com/awslabs/flux-swf-client</url>
+    <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://aws.amazon.com/apache2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -30,7 +30,7 @@
         <!-- flux internal dependencies -->
         <dependency>
             <artifactId>flux-common</artifactId>
-            <groupId>software.amazon.aws.clients.swf.flux</groupId>
+            <groupId>com.danielgmyers.flux.clients.swf</groupId>
             <version>${flux.version}</version>
             <optional>false</optional>
         </dependency>

--- a/flux/pom.xml
+++ b/flux/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>software.amazon.aws.clients.swf.flux</groupId>
+        <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
         <version>2.0.7</version>
     </parent>
     <artifactId>flux</artifactId>
     <name>Flux SWF Client</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
-    <url>https://github.com/awslabs/flux-swf-client</url>
+    <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://aws.amazon.com/apache2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -48,7 +48,7 @@
         <!-- flux internal dependencies -->
         <dependency>
             <artifactId>flux-common</artifactId>
-            <groupId>software.amazon.aws.clients.swf.flux</groupId>
+            <groupId>com.danielgmyers.flux.clients.swf</groupId>
             <version>${flux.version}</version>
             <optional>false</optional>
         </dependency>
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <artifactId>flux-testutils</artifactId>
-            <groupId>software.amazon.aws.clients.swf.flux</groupId>
+            <groupId>com.danielgmyers.flux.clients.swf</groupId>
             <version>${flux.version}</version>
             <scope>test</scope>
         </dependency>

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/WorkflowState.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/WorkflowState.java
@@ -263,7 +263,7 @@ final class WorkflowState {
                 // 2. If the retry attempt for this partition is zero, and this is the first time we've seen this partition id
                 //    (which will happen if only one attempt to schedule this partition was made, and it failed),
                 //    then we need to track that we've seen this partition id but have no metadata for it.
-                // See https://github.com/awslabs/flux-swf-client/issues/33 for details on why this is important.
+                // See https://github.com/danielgmyers/flux-swf-client/issues/33 for details on why this is important.
 
                 // We'll deal with this by treating it as if we know the partition id but have not yet scheduled it.
                 // We also have to extract the partition id from the activity id since it's not stored in the event data.

--- a/pom.xml
+++ b/pom.xml
@@ -2,25 +2,25 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>software.amazon.aws.clients.swf.flux</groupId>
+    <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf-client-pom</artifactId>
     <version>2.0.7</version>
     <packaging>pom</packaging>
     <name>Flux SWF Client POM</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
-    <url>https://github.com/awslabs/flux-swf-client</url>
+    <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://aws.amazon.com/apache2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
     <developers>
         <developer>
-            <id>amazonwebservices</id>
-            <organization>Amazon Web Services</organization>
-            <organizationUrl>https://aws.amazon.com</organizationUrl>
+            <id>danielgmyers</id>
+            <name>Dan Myers</name>
+            <url>https://github.com/danielgmyers</url>
             <roles>
                 <role>developer</role>
             </roles>
@@ -37,9 +37,9 @@
     </modules>
 
     <scm>
-        <connection>scm:git:https://github.com/awslabs/flux-swf-client.git</connection>
-        <developerConnection>scm:git:git@github.com:awslabs/flux-swf-client.git</developerConnection>
-        <url>https://github.com/awslabs/flux-swf-client</url>
+        <connection>scm:git:https://github.com/danielgmyers/flux-swf-client.git</connection>
+        <developerConnection>scm:git:git@github.com:danielgmyers/flux-swf-client.git</developerConnection>
+        <url>https://github.com/danielgmyers/flux-swf-client</url>
     </scm>
     <properties>
         <flux.version>${project.version}</flux.version>
@@ -206,7 +206,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://aws.oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>${publishing.autoReleaseAfterClose}</autoReleaseAfterClose>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
https://github.com/danielgmyers/flux-swf-client/issues/53

* Update project URLs in pom files.
* Update maven group ID (now com.danielgmyers.flux.clients.swf).
* Update maven staging repo URL.

https://github.com/danielgmyers/flux-swf-client/issues/56

* Update GitHub build workflow to use OIDC.
* Update the build badge in the README to point at the new CodeBuild project.
