### PR TITLE
Partial workflow execution tag support.

### DIFF
--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/AutomaticallyTagExecutionsWithTaskList.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/AutomaticallyTagExecutionsWithTaskList.java
@@ -1,0 +1,36 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.guice;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Should be attached to a Guice object referencing a Boolean which indicates whether Flux should
+ * automatically tag new workflow executions with the task list name.
+ *
+ * Users are not required to provide this; if not specified, the functionality will be enabled.
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@BindingAnnotation
+public @interface AutomaticallyTagExecutionsWithTaskList {
+}

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/FluxModule.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/FluxModule.java
@@ -104,6 +104,9 @@ public class FluxModule extends AbstractModule {
         if (configHolder.getExponentialBackoffBase() != null) {
             config.setExponentialBackoffBase(configHolder.getExponentialBackoffBase());
         }
+        if (configHolder.getAutomaticallyTagExecutionsWithTaskList() != null) {
+            config.setAutomaticallyTagExecutionsWithTaskList(configHolder.getAutomaticallyTagExecutionsWithTaskList());
+        }
         applyTaskListConfigData(config, configHolder.getTaskListBucketCounts(),
                                 TaskListConfig::setBucketCount);
         applyTaskListConfigData(config, configHolder.getTaskListActivityThreadCounts(),

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/FluxOptionalConfigHolder.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/FluxOptionalConfigHolder.java
@@ -26,6 +26,7 @@ import com.google.inject.Inject;
  */
 public class FluxOptionalConfigHolder {
 
+    private Boolean automaticallyTagExecutionsWithTaskList = null;
     private Double exponentialBackoffBase = null;
     private String swfEndpoint = null;
     private Map<String, Integer> taskListBucketCounts = null;
@@ -34,6 +35,16 @@ public class FluxOptionalConfigHolder {
     private Map<String, Integer> taskListDeciderThreadCounts = null;
     private Map<String, Integer> taskListDeciderPollerThreadCounts = null;
     private Map<String, Integer> taskListPeriodicSubmitterThreadCounts = null;
+
+    public Boolean getAutomaticallyTagExecutionsWithTaskList() {
+        return automaticallyTagExecutionsWithTaskList;
+    }
+
+    @Inject(optional = true)
+    public void setAutomaticallyTagExecutionsWithTaskList(
+            @AutomaticallyTagExecutionsWithTaskList Boolean automaticallyTagExecutionsWithTaskList) {
+        this.automaticallyTagExecutionsWithTaskList = automaticallyTagExecutionsWithTaskList;
+    }
 
     public Double getExponentialBackoffBase() {
         return exponentialBackoffBase;

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/BasicWorkflowTest.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/BasicWorkflowTest.java
@@ -17,6 +17,7 @@ import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
 import software.amazon.aws.clients.swf.flux.wf.Workflow;
 import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraph;
 import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraphBuilder;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Validates very basic workflow functionality.
@@ -36,13 +37,19 @@ public class BasicWorkflowTest extends WorkflowTestBase {
         String uuid = UUID.randomUUID().toString();
 
         executeWorkflow(HelloWorld.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertTrue(StepOne.didExecute(uuid));
 
         uuid = UUID.randomUUID().toString();
         executeWorkflow(HelloWorld.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+        info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertTrue(StepOne.didExecute(uuid));
     }

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/BranchingWorkflowTests.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/BranchingWorkflowTests.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
 import software.amazon.aws.clients.swf.flux.wf.Workflow;
 import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraph;
 import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraphBuilder;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Tests that validate Flux's behavior for branching workflows.
@@ -48,7 +50,10 @@ public class BranchingWorkflowTests extends WorkflowTestBase {
         executeWorkflow(BranchingWorkflowSucceedFail.class, uuid,
 
                         buildInput(BRANCH_ATTRIBUTE_NAME, StepResult.SUCCEED_RESULT_CODE));
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertEquals(2, EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).size());
         Assert.assertEquals(StepOne.class.getSimpleName(), EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).get(0));
@@ -59,7 +64,10 @@ public class BranchingWorkflowTests extends WorkflowTestBase {
 
         executeWorkflow(BranchingWorkflowSucceedFail.class, uuid,
                         buildInput(BRANCH_ATTRIBUTE_NAME, StepResult.FAIL_RESULT_CODE));
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+        info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertEquals(2, EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).size());
         Assert.assertEquals(StepOne.class.getSimpleName(), EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).get(0));
@@ -72,7 +80,10 @@ public class BranchingWorkflowTests extends WorkflowTestBase {
         EXECUTION_ORDER_BY_WORKFLOW_ID.put(uuid, Collections.synchronizedList(new LinkedList<>()));
 
         executeWorkflow(BranchingWorkflowCustomCodes.class, uuid, buildInput(BRANCH_ATTRIBUTE_NAME, BRANCH_LEFT));
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertEquals(2, EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).size());
         Assert.assertEquals(StepOne.class.getSimpleName(), EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).get(0));
@@ -82,7 +93,10 @@ public class BranchingWorkflowTests extends WorkflowTestBase {
         EXECUTION_ORDER_BY_WORKFLOW_ID.put(uuid, Collections.synchronizedList(new LinkedList<>()));
 
         executeWorkflow(BranchingWorkflowCustomCodes.class, uuid, buildInput(BRANCH_ATTRIBUTE_NAME, BRANCH_RIGHT));
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+        info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertEquals(2, EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).size());
         Assert.assertEquals(StepOne.class.getSimpleName(), EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).get(0));

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/BucketedTaskListTest.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/BucketedTaskListTest.java
@@ -58,6 +58,9 @@ public class BucketedTaskListTest extends WorkflowTestBase {
             executeWorkflow(BucketedHelloWorld.class, uuid, Collections.emptyMap());
             WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
 
+            // the execution tags should have the non-bucketed task list name
+            Assert.assertEquals(Collections.singleton(TASK_LIST_NAME), new HashSet<>(info.tagList()));
+
             GetWorkflowExecutionHistoryResponse response = getWorkflowExecutionHistory(uuid, info.execution().runId());
             Assert.assertTrue(response.hasEvents());
             String taskList = response.events().get(0).workflowExecutionStartedEventAttributes().taskList().name();

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/CustomSdkConfigurationTest.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/CustomSdkConfigurationTest.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Given an SwfClient object, there's not actually a way to check its configuration.
@@ -74,13 +75,19 @@ public class CustomSdkConfigurationTest extends WorkflowTestBase {
         String uuid = UUID.randomUUID().toString();
 
         executeWorkflow(HelloWorld.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertTrue(StepOne.didExecute(uuid));
 
         uuid = UUID.randomUUID().toString();
         executeWorkflow(HelloWorld.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+        info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertTrue(StepOne.didExecute(uuid));
     }

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/MultiStepWorkflowTests.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/MultiStepWorkflowTests.java
@@ -23,6 +23,7 @@ import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraphBuilder;
 import software.amazon.aws.clients.swf.flux.step.StepApply;
 import software.amazon.aws.clients.swf.flux.step.StepAttributes;
 import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Tests that validate Flux's behavior for multi-step workflows.
@@ -47,7 +48,10 @@ public class MultiStepWorkflowTests extends WorkflowTestBase {
         EXECUTION_ORDER_BY_WORKFLOW_ID.put(uuid, Collections.synchronizedList(new LinkedList<>()));
 
         executeWorkflow(MultiStep.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Assert.assertEquals(3, EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).size());
         Assert.assertEquals(StepOne.class.getSimpleName(), EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).get(0));
@@ -66,7 +70,10 @@ public class MultiStepWorkflowTests extends WorkflowTestBase {
         }
 
         for (String uuid : uuids) {
-            waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+            WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+            Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                                new HashSet<>(info.tagList()));
 
             Assert.assertEquals(3, EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).size());
             Assert.assertEquals(StepOne.class.getSimpleName(), EXECUTION_ORDER_BY_WORKFLOW_ID.get(uuid).get(0));

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/PartitionedWorkflowTests.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/PartitionedWorkflowTests.java
@@ -25,6 +25,7 @@ import software.amazon.aws.clients.swf.flux.step.PartitionedWorkflowStep;
 import software.amazon.aws.clients.swf.flux.step.StepApply;
 import software.amazon.aws.clients.swf.flux.step.StepAttributes;
 import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Tests that validate Flux's behavior for partitioned workflows.
@@ -45,7 +46,10 @@ public class PartitionedWorkflowTests extends WorkflowTestBase {
     public void testPartitionedWorkflowStepExecutesAllPartitions() throws InterruptedException {
         String uuid = UUID.randomUUID().toString();
         executeWorkflow(PartitionedGreeting.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         Set<String> partitionIds = PartitionedStep.getGeneratedPartitionsByWorkflowId().get(uuid);
         Assert.assertEquals(partitionIds.size(), PartitionedStep.getExecutedPartitionsByWorkflowId().get(uuid).size());
@@ -65,7 +69,11 @@ public class PartitionedWorkflowTests extends WorkflowTestBase {
 
 
         for (String uuid : uuids) {
-            waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+            WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+
+            Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                                new HashSet<>(info.tagList()));
+
             Set<String> partitionIds = PartitionedStep.getGeneratedPartitionsByWorkflowId().get(uuid);
             Assert.assertEquals(partitionIds.size(), PartitionedStep.getExecutedPartitionsByWorkflowId().get(uuid).size());
             for (String id : partitionIds) {

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/RemoteWorkflowTest.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/RemoteWorkflowTest.java
@@ -65,6 +65,8 @@ public class RemoteWorkflowTest extends WorkflowTestBase {
         WorkflowStatusChecker.WorkflowStatus lastStatus = status.checkStatus();
         log.info("Received status " + lastStatus.toString() + " for requested remote workflow.");
 
+        // TODO -- check that the remote execution was tagged with the task list name.
+
         Assert.assertEquals(WorkflowStatusChecker.WorkflowStatus.IN_PROGRESS, status.checkStatus());
 
         terminateOpenWorkflowExecutions(status.getSwfClient());

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/SignalTests.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/SignalTests.java
@@ -3,6 +3,7 @@ package software.amazon.aws.clients.swf.flux.tests;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,6 +23,7 @@ import software.amazon.aws.clients.swf.flux.step.StepApply;
 import software.amazon.aws.clients.swf.flux.step.StepAttributes;
 import software.amazon.aws.clients.swf.flux.step.StepResult;
 import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Tests that validate Flux's signal support.
@@ -54,7 +56,10 @@ public class SignalTests extends WorkflowTestBase {
                                 String.format("{\"activityId\": \"%s\", \"resultCode\": \"%s\" }",
                                               String.format("%s_%s", AlwaysRetries.class.getSimpleName(), 2),
                                               RESULT_CODE_THAT_CLOSES_WORKFLOW));
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         // since we forced the workflow to close, it should have closed without running the step again.
         Assert.assertEquals(2, AlwaysRetries.getAttemptCount());
@@ -78,7 +83,10 @@ public class SignalTests extends WorkflowTestBase {
                                 String.format("{\"activityId\": \"%s\", \"resultCode\": \"%s\" }",
                                               String.format("%s_%s", SucceedWithCustomResultCode.class.getSimpleName(), 1),
                                               StepResult.SUCCEED_RESULT_CODE));
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(30));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         // since we forced the workflow to close, it should have closed without running the step again.
         Assert.assertEquals(1, SucceedWithCustomResultCode.getAttemptCount());
@@ -97,7 +105,10 @@ public class SignalTests extends WorkflowTestBase {
         Thread.sleep(40000);
         Assert.assertEquals(2, SucceedsOnRetryAttemptOne.getAttemptCount());
 
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(10));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(10));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         // It should have closed without running the step again.
         Assert.assertEquals(2, SucceedsOnRetryAttemptOne.getAttemptCount());
@@ -119,7 +130,10 @@ public class SignalTests extends WorkflowTestBase {
         Thread.sleep(10000);
         Assert.assertEquals(4, SucceedsOnRetryAttemptOne.getAttemptCount());
 
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(10));
+        info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(10));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         // It should have closed without running the step again.
         Assert.assertEquals(4, SucceedsOnRetryAttemptOne.getAttemptCount());
@@ -150,7 +164,10 @@ public class SignalTests extends WorkflowTestBase {
         Thread.sleep(30000);
         Assert.assertEquals(2, SucceedsOnRetryAttemptTwo.getAttemptCount());
 
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(120));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(120));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
 
         // Since the workflow only ends after its second retry attempt (third step execution), there should be three attempts now.
         Assert.assertEquals(3, SucceedsOnRetryAttemptTwo.getAttemptCount());

--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/WorkflowStepRetryTests.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/WorkflowStepRetryTests.java
@@ -3,9 +3,11 @@ package software.amazon.aws.clients.swf.flux.tests;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import software.amazon.aws.clients.swf.flux.step.Attribute;
@@ -17,6 +19,7 @@ import software.amazon.aws.clients.swf.flux.step.StepApply;
 import software.amazon.aws.clients.swf.flux.step.StepAttributes;
 import software.amazon.aws.clients.swf.flux.step.StepResult;
 import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Validates that the two ways a step can retry both result in retries and that workflows can still complete afterward.
@@ -36,7 +39,10 @@ public class WorkflowStepRetryTests extends WorkflowTestBase {
         String uuid = UUID.randomUUID().toString();
 
         executeWorkflow(WorkflowWithRetryingStep.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
     }
 
     /**
@@ -47,7 +53,10 @@ public class WorkflowStepRetryTests extends WorkflowTestBase {
         String uuid = UUID.randomUUID().toString();
 
         executeWorkflow(WorkflowWithExceptionThrowingStep.class, uuid, Collections.emptyMap());
-        waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+        WorkflowExecutionInfo info = waitForWorkflowCompletion(uuid, Duration.ofSeconds(60));
+
+        Assert.assertEquals(Collections.singleton(Workflow.DEFAULT_TASK_LIST_NAME),
+                            new HashSet<>(info.tagList()));
     }
 
     /**

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitorConfig.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitorConfig.java
@@ -35,6 +35,7 @@ public class FluxCapacitorConfig {
     private String swfDomain;
     private ClientOverrideConfiguration clientOverrideConfiguration;
     private final Map<String, TaskListConfig> taskListConfigs = new HashMap<>();
+    private Boolean automaticallyTagExecutionsWithTaskList;
 
     public String getAwsRegion() {
         return awsRegion;
@@ -260,5 +261,18 @@ public class FluxCapacitorConfig {
                 getTaskListConfig(entry.getKey()).setPeriodicSubmitterThreadCount(entry.getValue());
             }
         }
+    }
+
+    /**
+     * Controls whether Flux automatically includes a workflow's task list name in the list of tags for new executions.
+     *
+     * This configuration value is optional; if not specified, this functionality will be enabled.
+     */
+    public void setAutomaticallyTagExecutionsWithTaskList(Boolean automaticallyTagExecutionsWithTaskList) {
+        this.automaticallyTagExecutionsWithTaskList = automaticallyTagExecutionsWithTaskList;
+    }
+
+    public Boolean getAutomaticallyTagExecutionsWithTaskList() {
+        return automaticallyTagExecutionsWithTaskList;
     }
 }

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/RemoteWorkflowExecutorImpl.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/RemoteWorkflowExecutorImpl.java
@@ -17,7 +17,9 @@
 package software.amazon.aws.clients.swf.flux;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,10 +62,15 @@ public class RemoteWorkflowExecutorImpl implements RemoteWorkflowExecutor {
         }
 
         Workflow workflow = workflowsByName.get(workflowName);
+
+        Set<String> executionTags = new HashSet<>();
+        // TODO -- check if enabled
+        executionTags.add(workflow.taskList());
+
         StartWorkflowExecutionRequest request
                 = FluxCapacitorImpl.buildStartWorkflowRequest(workflowDomain, workflowName, workflowId,
                                                               workflow.taskList(), workflow.maxStartToCloseDuration(),
-                                                              workflowInput);
+                                                              workflowInput, executionTags);
 
         log.debug("Requesting new remote workflow execution for workflow {} with id {}", workflowName, workflowId);
 

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/RemoteWorkflowExecutorTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/RemoteWorkflowExecutorTest.java
@@ -121,10 +121,12 @@ public class RemoteWorkflowExecutorTest {
         expectStartWorkflowRequest(workflow, workflowId, input, null);
     }
 
-    private void expectStartWorkflowRequest(Workflow workflow, String workflowId, Map<String, Object> input, Exception exceptionToThrow) {
-        StartWorkflowExecutionRequest start = FluxCapacitorImpl.buildStartWorkflowRequest(DOMAIN, TaskNaming.workflowName(workflow),
-                                                                                          workflowId, workflow.taskList(),
-                                                                                          workflow.maxStartToCloseDuration(), input);
+    private void expectStartWorkflowRequest(Workflow workflow, String workflowId, Map<String, Object> input,
+                                            Exception exceptionToThrow) {
+        StartWorkflowExecutionRequest start
+                = FluxCapacitorImpl.buildStartWorkflowRequest(DOMAIN, TaskNaming.workflowName(workflow), workflowId,
+                                                              workflow.taskList(), workflow.maxStartToCloseDuration(),
+                                                              input, Collections.singleton(workflow.taskList()));
         if (exceptionToThrow == null) {
             StartWorkflowExecutionResponse workflowRun = StartWorkflowExecutionResponse.builder().runId("run-id").build();
             EasyMock.expect(swf.startWorkflowExecution(start)).andReturn(workflowRun);


### PR DESCRIPTION
https://github.com/danielgmyers/flux-swf-client/issues/60

* Automatically tag workflow executions with the task list name.
* Add config flag for enabling/disabling the auto-tagging functionality.
* Add annotation and wiring to flux-guice for the new config flag.
* Update integration tests to verify execution tags.

I'll follow this up with another change to support custom execution tags passed as a parameter to `FluxCapacitor.executeWorkflow()`.