### PR TITLE
Change integration test config

### DIFF
--- a/flux-integration-tests/pom.xml
+++ b/flux-integration-tests/pom.xml
@@ -62,11 +62,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <!-- The integration tests make a lot of network requests,
-                         so this limits how much happens concurrently -->
-                    <threadCount>2</threadCount>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/BasicWorkflowTest.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/BasicWorkflowTest.java
@@ -16,17 +16,30 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraph;
 import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Validates very basic workflow functionality.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class BasicWorkflowTest extends WorkflowTestBase {
+    private static final Logger log = LoggerFactory.getLogger(BasicWorkflowTest.class);
 
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Collections.singletonList(new HelloWorld());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     /**

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/BranchingWorkflowTests.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/BranchingWorkflowTests.java
@@ -20,6 +20,9 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraph;
 import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +31,8 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 /**
  * Tests that validate Flux's behavior for branching workflows.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class BranchingWorkflowTests extends WorkflowTestBase {
 
     private static final String BRANCH_ATTRIBUTE_NAME = "branch";
@@ -40,6 +45,11 @@ public class BranchingWorkflowTests extends WorkflowTestBase {
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Arrays.asList(new BranchingWorkflowSucceedFail(), new BranchingWorkflowCustomCodes());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     @Test

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/BucketedTaskListTest.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/BucketedTaskListTest.java
@@ -19,6 +19,9 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraph;
 import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +31,8 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 /**
  * Validates bucketed task list functionality.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class BucketedTaskListTest extends WorkflowTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(BucketedTaskListTest.class);
@@ -37,6 +42,11 @@ public class BucketedTaskListTest extends WorkflowTestBase {
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Collections.singletonList(new BucketedHelloWorld());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     @Override

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/CustomSdkConfigurationTest.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/CustomSdkConfigurationTest.java
@@ -19,6 +19,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -32,7 +37,10 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
  * got wired into the SwfClient, we'll configure it with an execution interceptor
  * and verify that the interceptor got called during the HelloWorld workflow.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class CustomSdkConfigurationTest extends WorkflowTestBase {
+    private static final Logger log = LoggerFactory.getLogger(CustomSdkConfigurationTest.class);
 
     private boolean interceptorCalled;
 
@@ -64,6 +72,11 @@ public class CustomSdkConfigurationTest extends WorkflowTestBase {
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Collections.singletonList(new HelloWorld());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     /**

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/MultiStepWorkflowTests.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/MultiStepWorkflowTests.java
@@ -19,6 +19,9 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraph;
 import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +30,8 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 /**
  * Tests that validate Flux's behavior for multi-step workflows.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class MultiStepWorkflowTests extends WorkflowTestBase {
     private static final Logger log = LoggerFactory.getLogger(MultiStepWorkflowTests.class);
 
@@ -35,6 +40,11 @@ public class MultiStepWorkflowTests extends WorkflowTestBase {
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Collections.singletonList(new MultiStep());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     int getWorkerPoolThreadCount() {

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/PartitionedWorkflowTests.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/PartitionedWorkflowTests.java
@@ -21,6 +21,9 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraph;
 import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,12 +32,19 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 /**
  * Tests that validate Flux's behavior for partitioned workflows.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class PartitionedWorkflowTests extends WorkflowTestBase {
     private final static Logger log = LoggerFactory.getLogger(PartitionedWorkflowTests.class);
 
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Collections.singletonList(new PartitionedGreeting());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     int getWorkerPoolThreadCount() {

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/PeriodicWorkflowTests.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/PeriodicWorkflowTests.java
@@ -13,18 +13,28 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraph;
 import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Tests that validate Flux's behavior for @Periodic workflows.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class PeriodicWorkflowTests extends WorkflowTestBase {
     private static final Logger log = LoggerFactory.getLogger(PeriodicWorkflowTests.class);
 
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Collections.singletonList(new PeriodicHello());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     /**

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/RemoteWorkflowTest.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/RemoteWorkflowTest.java
@@ -20,6 +20,9 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,12 +31,19 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 /**
  * Validates we can run workflows against a remote region.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class RemoteWorkflowTest extends WorkflowTestBase {
     private static final Logger log = LoggerFactory.getLogger(RemoteWorkflowTest.class);
 
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Collections.singletonList(new HelloWorld());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     /**

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/WorkflowStepRetryTests.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/WorkflowStepRetryTests.java
@@ -17,17 +17,31 @@ import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraph;
 import com.danielgmyers.flux.clients.swf.wf.graph.WorkflowGraphBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 
 /**
  * Validates that the two ways a step can retry both result in retries and that workflows can still complete afterward.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
 public class WorkflowStepRetryTests extends WorkflowTestBase {
+    private static final Logger log = LoggerFactory.getLogger(WorkflowStepRetryTests.class);
+
     @Override
     List<Workflow> getWorkflowsForTest() {
         return Arrays.asList(new WorkflowWithRetryingStep(),
                              new WorkflowWithExceptionThrowingStep());
+    }
+
+    @Override
+    Logger getLogger() {
+        return log;
     }
 
     /**

--- a/flux-integration-tests/src/test/resources/junit-platform.properties
+++ b/flux-integration-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.config.fixed.parallelism = 2


### PR DESCRIPTION
In particular, this significantly speeds up integration test runs.

* Flux is now initialized once per test class, rather than once per test method. This allows us to skip waiting 60s for Flux to shut down between individual tests.
* Multiple tests can run in parallel.
* SignalTests' test workflow steps were updated to work with multiple tests running at a time.