### PR TITLE
Flux unit tests finish in ~20s now instead of ~1m20s, by running in parallel.

### DIFF
--- a/flux/src/test/java/com/danielgmyers/flux/clients/swf/poller/ActivityTaskPollerTest.java
+++ b/flux/src/test/java/com/danielgmyers/flux/clients/swf/poller/ActivityTaskPollerTest.java
@@ -42,6 +42,8 @@ import org.easymock.IMocksControl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.swf.SwfClient;
@@ -60,6 +62,7 @@ import software.amazon.awssdk.services.swf.model.TaskList;
 import software.amazon.awssdk.services.swf.model.UnknownResourceException;
 import software.amazon.awssdk.services.swf.model.WorkflowExecution;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ActivityTaskPollerTest {
 
     public static class DummyStep implements WorkflowStep {

--- a/flux/src/test/resources/junit-platform.properties
+++ b/flux/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.config.fixed.parallelism = 4


### PR DESCRIPTION
Nearly all of the time is spent in ActivityTaskPollerTest, testing the heartbeat logic.