### PR TITLE
Make the Flux common interface fully independent of SWF.

### DIFF
--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -33,9 +33,9 @@
             <optional>false</optional>
         </dependency>
         <dependency>
-            <artifactId>swf</artifactId>
-            <groupId>software.amazon.awssdk</groupId>
-            <version>${awssdk.version}</version>
+            <artifactId>slf4j-api</artifactId>
+            <groupId>org.slf4j</groupId>
+            <version>${slf4j.version}</version>
             <optional>false</optional>
         </dependency>
 

--- a/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitor.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitor.java
@@ -23,8 +23,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.danielgmyers.flux.clients.swf.wf.Workflow;
 
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-
 /**
  * The primary interface through which the Flux library is used at runtime.
  */
@@ -65,10 +63,15 @@ public interface FluxCapacitor {
                                           Set<String> executionTags);
 
     /**
-     * Returns an object that can submit workflow executions against a different region/endpoint and with different credentials.
+     * Returns an object that can submit workflow executions to another workflow service endpoint.
+     * The FluxCapacitor implementation will require one or more callbacks to be provided via configuration
+     * to look up the necessary information to initialize the underlying client.
+     *
+     * @param endpointId This should be an identifier that can be used by the aforementioned configuration callbacks to determine
+     *                   which configuration data to supply to the underlying client.
+     * @param workflowDomain The domain that the remote workflows should be executed in.
      */
-    RemoteWorkflowExecutor getRemoteWorkflowExecutor(String swfRegion, String swfEndpoint, AwsCredentialsProvider credentials,
-                                                     String workflowDomain);
+    RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId, String workflowDomain);
 
     /**
      * Shuts down this FluxCapacitor object's worker thread pools. Running threads are not interrupted.

--- a/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutor.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutor.java
@@ -24,7 +24,7 @@ import com.danielgmyers.flux.clients.swf.wf.Workflow;
 /**
  * Represents an object that can execute workflows against a different endpoint and/or using different credentials
  * than the main FluxCapacitor. Should be used only when there is no cleaner way to do cross-region or
- * cross-acount operations (e.g. when there are no API endpoints available other than the SWF endpoints).
+ * cross-account operations (e.g. when there are no API endpoints available other than the workflow service endpoints).
  *
  * Some caveats: this assumes you're already running the real FluxCapacitor against the remote region in the provided account,
  * which should take care of registering workflows, domains, etc.

--- a/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/WorkflowStatusChecker.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/WorkflowStatusChecker.java
@@ -16,8 +16,8 @@
 
 package com.danielgmyers.flux.clients.swf;
 
-import software.amazon.awssdk.services.swf.SwfClient;
-import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
+import com.danielgmyers.flux.clients.swf.wf.WorkflowInfo;
+import com.danielgmyers.flux.clients.swf.wf.WorkflowStatus;
 
 /**
  * Allows checking the status of a workflow execution. Obtained from a FluxCapacitor or RemoteWorkflowExecutor.
@@ -25,24 +25,20 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
 public interface WorkflowStatusChecker {
 
     /**
-     * Represents the status of a workflow. This is a composite of the workflow's ExecutionStatus and CloseStatus.
-     */
-    enum WorkflowStatus { IN_PROGRESS, COMPLETED, FAILED, CANCELED, TERMINATED, TIMED_OUT, UNKNOWN }
-
-    /**
-     * Queries SWF to determine the status of the associated workflow execution.
+     * Queries the workflow service to determine the status of the associated workflow execution.
      * Returns WorkflowStatus.UNKNOWN if the status could not be retrieved.
      */
-    WorkflowStatus checkStatus();
+    default WorkflowStatus checkStatus() {
+        WorkflowInfo info = getWorkflowInfo();
+        if (info == null) {
+            return WorkflowStatus.UNKNOWN;
+        }
+        return info.getWorkflowStatus();
+    }
 
     /**
-     * Queries SWF to retrieve the current WorkflowExecutionInfo for the associated execution.
-     * May return null if the execution info could not be retrieved.
+     * Queries the workflow service to retrieve detailed information about the workflow execution.
+     * May return null if the information could not be retrieved.
      */
-    WorkflowExecutionInfo getExecutionInfo();
-
-    /**
-     * Useful primarily in integration tests, this allows the raw SWF client to be retrieved from the status checker.
-     */
-    SwfClient getSwfClient();
+    WorkflowInfo getWorkflowInfo();
 }

--- a/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/wf/WorkflowInfo.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/wf/WorkflowInfo.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.wf;
+
+import java.time.Instant;
+import java.util.Set;
+
+/**
+ * Provides a point-in-time snapshot of information about a workflow execution.
+ */
+public interface WorkflowInfo {
+
+    /**
+     * Returns the time at which this snapshot was generated.
+     */
+    Instant getSnapshotTime();
+
+    /**
+     * Returns the user-specified workflow identifier, i.e. the value provided to FluxCapacitor.executeWorkflow().
+     */
+    String getWorkflowId();
+
+    /**
+     * Returns the system-generated identifier specific to this workflow execution.
+     */
+    String getExecutionId();
+
+    /**
+     * Returns the status of the workflow at this point in time.
+     */
+    WorkflowStatus getWorkflowStatus();
+
+    /**
+     * Returns the execution tags associated with this workflow execution.
+     */
+    Set<String> getExecutionTags();
+}

--- a/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/wf/WorkflowStatus.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/clients/swf/wf/WorkflowStatus.java
@@ -1,0 +1,30 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.wf;
+
+/**
+ * Represents the status of a workflow.
+ */
+public enum WorkflowStatus {
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED,
+    CANCELED,
+    TERMINATED,
+    TIMED_OUT,
+    UNKNOWN
+}

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/TestConfig.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/TestConfig.java
@@ -21,24 +21,13 @@ public final class TestConfig {
     }
 
     /**
-     * Retrieves the configured SWF endpoint.
+     * Retrieves the configured remote region.
      */
-    public static String getSwfEndpoint() {
-        return System.getProperty("swfEndpoint", null);
-    }
-
-    /**
-     * Gets the region to be used in the Remote Workflow tests.
-     */
-    public static String getRemoteRegion() {
-        return System.getProperty("remoteRegion", "us-east-1");
-    }
-
-    /**
-     * Gets the SWF endpoint to be used in the Remote Workflow tests.
-     */
-    public static String getRemoteEndpoint() {
-        return System.getProperty("remoteEndpoint", null);
+    public static RemoteSwfClientConfig getRemoteClientConfig() {
+        RemoteSwfClientConfig config = new RemoteSwfClientConfig();
+        config.setAwsRegion(System.getProperty("remoteRegion", "us-east-1"));
+        config.setSwfEndpoint(System.getProperty("remoteEndpoint", null));
+        return config;
     }
 
     /**
@@ -49,7 +38,7 @@ public final class TestConfig {
      * @param workerPoolSize - the size of the thread pool for the deciders and workers.
      */
     public static FluxCapacitorConfig generateFluxConfig(String swfDomain, int workerPoolSize) {
-        return generateFluxConfig(getAwsRegion(), getSwfEndpoint(), swfDomain, workerPoolSize);
+        return generateFluxConfig(getAwsRegion(), swfDomain, workerPoolSize);
     }
 
     /**
@@ -60,15 +49,13 @@ public final class TestConfig {
      * @param workerPoolSize - the size of the thread pool for the deciders and workers.
      */
     public static FluxCapacitorConfig generateRemoteFluxConfig(String swfDomain, int workerPoolSize) {
-        return generateFluxConfig(getRemoteRegion(), getRemoteEndpoint(), swfDomain, workerPoolSize);
+        RemoteSwfClientConfig remoteConfig = getRemoteClientConfig();
+        return generateFluxConfig(remoteConfig.getAwsRegion(), swfDomain, workerPoolSize);
     }
 
-    private static FluxCapacitorConfig generateFluxConfig(String region, String endpoint, String domain, int poolSize) {
+    private static FluxCapacitorConfig generateFluxConfig(String region, String domain, int poolSize) {
         FluxCapacitorConfig config = new FluxCapacitorConfig();
         config.setAwsRegion(region);
-        if (endpoint != null) {
-            config.setSwfEndpoint(endpoint); // endpoint is determined automatically from region if endpoint is not set
-        }
         config.setSwfDomain(domain);
 
         TaskListConfig tasklistConfig = new TaskListConfig();

--- a/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/WorkflowTestBase.java
+++ b/flux-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/WorkflowTestBase.java
@@ -51,8 +51,7 @@ public abstract class WorkflowTestBase {
     }
 
     protected RemoteWorkflowExecutor getRemoteWorkflowExecutor() {
-        return capacitor.getRemoteWorkflowExecutor(TestConfig.getRemoteRegion(), TestConfig.getRemoteEndpoint(),
-                                                   DefaultCredentialsProvider.create(), getWorkflowDomain());
+        return capacitor.getRemoteWorkflowExecutor("test", getWorkflowDomain());
     }
 
     abstract List<Workflow> getWorkflowsForTest();
@@ -81,15 +80,9 @@ public abstract class WorkflowTestBase {
     protected SwfClient createSwfClient(boolean localRegion) {
         SwfClientBuilder swfClientBuilder = SwfClient.builder().credentialsProvider(DefaultCredentialsProvider.create());
         if (localRegion) {
-            if (TestConfig.getSwfEndpoint() != null) {
-                swfClientBuilder.endpointOverride(URI.create(TestConfig.getSwfEndpoint()));
-            }
             swfClientBuilder.region(Region.of(TestConfig.getAwsRegion()));
         } else {
-            if (TestConfig.getRemoteEndpoint() != null) {
-                swfClientBuilder.endpointOverride(URI.create(TestConfig.getRemoteEndpoint()));
-            }
-            swfClientBuilder.region(Region.of(TestConfig.getRemoteRegion()));
+            swfClientBuilder.region(Region.of(TestConfig.getRemoteClientConfig().getAwsRegion()));
         }
         return swfClientBuilder.build();
     }
@@ -102,6 +95,7 @@ public abstract class WorkflowTestBase {
         }  else {
             config = TestConfig.generateRemoteFluxConfig(getWorkflowDomain(), getWorkerPoolThreadCount());
         }
+        config.setRemoteSwfClientConfigProvider((s) -> TestConfig.getRemoteClientConfig());
         updateFluxCapacitorConfig(config);
         FluxCapacitor capacitor = FluxCapacitorFactory.create(new NoopMetricRecorderFactory(),
                                                               DefaultCredentialsProvider.create(), config);

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -20,13 +20,6 @@
     </licenses>
 
     <dependencies>
-        <dependency>
-            <artifactId>swf</artifactId>
-            <groupId>software.amazon.awssdk</groupId>
-            <version>${awssdk.version}</version>
-            <optional>false</optional>
-        </dependency>
-
         <!-- flux internal dependencies -->
         <dependency>
             <artifactId>flux-common</artifactId>
@@ -40,12 +33,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit5.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flux-testutils/src/main/java/com/danielgmyers/flux/clients/swf/testutil/StubFluxCapacitor.java
+++ b/flux-testutils/src/main/java/com/danielgmyers/flux/clients/swf/testutil/StubFluxCapacitor.java
@@ -31,10 +31,6 @@ import com.danielgmyers.flux.clients.swf.poller.TaskNaming;
 import com.danielgmyers.flux.clients.swf.step.StepAttributes;
 import com.danielgmyers.flux.clients.swf.wf.Workflow;
 
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.services.swf.SwfClient;
-import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
-
 /**
  * A stub FluxCapacitor implementation intended to be used by unit tests.
  */
@@ -97,27 +93,13 @@ public class StubFluxCapacitor implements FluxCapacitor {
             }
             executedWorkflows.put(execution, Collections.unmodifiableMap(inputCopy));
         }
-        return new WorkflowStatusChecker() {
-            // TODO -- make some way for the test to control what checkStatus returns
-            @Override
-            public WorkflowStatus checkStatus() {
-                return WorkflowStatus.UNKNOWN;
-            }
 
-            @Override
-            public WorkflowExecutionInfo getExecutionInfo() {
-                return null;
-            }
-
-            public SwfClient getSwfClient() {
-                return null;
-            }
-        };
+        // TODO -- make some way for the test to control what this returns
+        return () -> null;
     }
 
     @Override
-    public RemoteWorkflowExecutor getRemoteWorkflowExecutor(String swfRegion, String swfEndpoint,
-                                                            AwsCredentialsProvider credentials, String workflowDomain) {
+    public RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId, String workflowDomain) {
         return new StubRemoteWorkflowExecutor();
     }
 

--- a/flux-testutils/src/main/java/com/danielgmyers/flux/clients/swf/testutil/StubRemoteWorkflowExecutor.java
+++ b/flux-testutils/src/main/java/com/danielgmyers/flux/clients/swf/testutil/StubRemoteWorkflowExecutor.java
@@ -27,9 +27,6 @@ import com.danielgmyers.flux.clients.swf.poller.TaskNaming;
 import com.danielgmyers.flux.clients.swf.step.StepAttributes;
 import com.danielgmyers.flux.clients.swf.wf.Workflow;
 
-import software.amazon.awssdk.services.swf.SwfClient;
-import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
-
 /**
  * Stub implementation of the RemoteWorkflowExecutor interface, useful for writing unit tests against Flux.
  */
@@ -54,21 +51,8 @@ public class StubRemoteWorkflowExecutor implements RemoteWorkflowExecutor {
     public WorkflowStatusChecker executeWorkflow(Class<? extends Workflow> workflowType, String workflowId,
                                                  Map<String, Object> workflowInput, Set<String> executionTags) {
         executedWorkflows.put(new WorkflowExecutionRecord(workflowType, workflowId), workflowInput);
-        return new WorkflowStatusChecker() {
-            @Override
-            public WorkflowStatus checkStatus() {
-                return WorkflowStatus.UNKNOWN;
-            }
-
-            @Override
-            public WorkflowExecutionInfo getExecutionInfo() {
-                return null;
-            }
-
-            public SwfClient getSwfClient() {
-                return null;
-            }
-        };
+        // TODO -- make some way for the test to control what this returns
+        return () -> null;
     }
 
     /**

--- a/flux/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorConfig.java
+++ b/flux/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorConfig.java
@@ -36,6 +36,7 @@ public class FluxCapacitorConfig {
     private ClientOverrideConfiguration clientOverrideConfiguration;
     private final Map<String, TaskListConfig> taskListConfigs = new HashMap<>();
     private Boolean automaticallyTagExecutionsWithTaskList;
+    private Function<String, RemoteSwfClientConfig> remoteSwfClientConfigProvider;
 
     public String getAwsRegion() {
         return awsRegion;
@@ -274,5 +275,19 @@ public class FluxCapacitorConfig {
 
     public Boolean getAutomaticallyTagExecutionsWithTaskList() {
         return automaticallyTagExecutionsWithTaskList;
+    }
+
+    /**
+     * Specifies a callback function that Flux can use to retrieve configuration for a RemoteWorkflowExecutor.
+     * The input to this callback is an arbitrary "endpoint id". This string is provided by the user
+     * as input to FluxCapacitor.getRemoteWorkflowExecutor().
+     * For example, the user might choose to map the endpoint id "standby-region" to a particular remote region config.
+     */
+    public void setRemoteSwfClientConfigProvider(Function<String, RemoteSwfClientConfig> remoteSwfClientConfigProvider) {
+        this.remoteSwfClientConfigProvider = remoteSwfClientConfigProvider;
+    }
+
+    public Function<String, RemoteSwfClientConfig> getRemoteSwfClientConfigProvider() {
+        return remoteSwfClientConfigProvider;
     }
 }

--- a/flux/src/main/java/com/danielgmyers/flux/clients/swf/RemoteSwfClientConfig.java
+++ b/flux/src/main/java/com/danielgmyers/flux/clients/swf/RemoteSwfClientConfig.java
@@ -1,0 +1,65 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+
+/**
+ * Allows users to provide SWF client configuration to be used to create a RemoteWorkflowExecutor.
+ * Note that at a minimum, the AWS region must not be null.
+ * If credentials is null, DefaultCredentialsProvider will be used.
+ * If swfEndpoint and clientOverrideConfiguration are null they will be ignored.
+ */
+public class RemoteSwfClientConfig {
+    private String awsRegion;
+    private String swfEndpoint;
+    private AwsCredentialsProvider credentials;
+    private ClientOverrideConfiguration clientOverrideConfiguration;
+
+    public String getAwsRegion() {
+        return awsRegion;
+    }
+
+    public void setAwsRegion(String awsRegion) {
+        this.awsRegion = awsRegion;
+    }
+
+    public String getSwfEndpoint() {
+        return swfEndpoint;
+    }
+
+    public void setSwfEndpoint(String swfEndpoint) {
+        this.swfEndpoint = swfEndpoint;
+    }
+
+    public AwsCredentialsProvider getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(AwsCredentialsProvider credentials) {
+        this.credentials = credentials;
+    }
+
+    public ClientOverrideConfiguration getClientOverrideConfiguration() {
+        return clientOverrideConfiguration;
+    }
+
+    public void setClientOverrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration) {
+        this.clientOverrideConfiguration = clientOverrideConfiguration;
+    }
+}

--- a/flux/src/main/java/com/danielgmyers/flux/clients/swf/SwfWorkflowInfo.java
+++ b/flux/src/main/java/com/danielgmyers/flux/clients/swf/SwfWorkflowInfo.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.danielgmyers.flux.clients.swf.wf.WorkflowInfo;
+import com.danielgmyers.flux.clients.swf.wf.WorkflowStatus;
+
+import software.amazon.awssdk.services.swf.model.ExecutionStatus;
+import software.amazon.awssdk.services.swf.model.WorkflowExecutionInfo;
+
+public class SwfWorkflowInfo implements WorkflowInfo {
+
+    private Instant snapshotTime;
+    private WorkflowExecutionInfo workflowExecutionInfo;
+
+    public SwfWorkflowInfo(Instant snapshotTime, WorkflowExecutionInfo workflowExecutionInfo) {
+        this.snapshotTime = snapshotTime;
+        this.workflowExecutionInfo = workflowExecutionInfo;
+    }
+
+    @Override
+    public Instant getSnapshotTime() {
+        return snapshotTime;
+    }
+
+    @Override
+    public String getWorkflowId() {
+        return workflowExecutionInfo.execution().workflowId();
+    }
+
+    @Override
+    public String getExecutionId() {
+        return workflowExecutionInfo.execution().runId();
+    }
+
+    @Override
+    public WorkflowStatus getWorkflowStatus() {
+        if (ExecutionStatus.OPEN == workflowExecutionInfo.executionStatus()) {
+            return WorkflowStatus.IN_PROGRESS;
+        }
+        switch (workflowExecutionInfo.closeStatus()) {
+            case FAILED:
+                return WorkflowStatus.FAILED;
+            case CANCELED:
+                return WorkflowStatus.CANCELED;
+            case TERMINATED:
+                return WorkflowStatus.TERMINATED;
+            case TIMED_OUT:
+                return WorkflowStatus.TIMED_OUT;
+            case COMPLETED:
+            case CONTINUED_AS_NEW:
+            case UNKNOWN_TO_SDK_VERSION: // we'll treat this as completed since we don't know what else to do.
+            default:
+                return WorkflowStatus.COMPLETED;
+        }
+    }
+
+    @Override
+    public Set<String> getExecutionTags() {
+        return new HashSet<>(workflowExecutionInfo.tagList());
+    }
+}

--- a/flux/src/test/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutorTest.java
+++ b/flux/src/test/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutorTest.java
@@ -16,6 +16,7 @@
 
 package com.danielgmyers.flux.clients.swf;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,6 +26,7 @@ import com.danielgmyers.flux.clients.swf.metrics.NoopMetricRecorderFactory;
 import com.danielgmyers.flux.clients.swf.poller.TaskNaming;
 import com.danielgmyers.flux.clients.swf.poller.testwf.TestWorkflow;
 import com.danielgmyers.flux.clients.swf.poller.testwf.TestWorkflowWithPartitionedStep;
+import com.danielgmyers.flux.clients.swf.util.ManualClock;
 import com.danielgmyers.flux.clients.swf.wf.Workflow;
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;
@@ -39,6 +41,7 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecutionAlreadyStarted
 
 public class RemoteWorkflowExecutorTest {
 
+    private ManualClock clock;
     private IMocksControl mockery;
     private SwfClient swf;
     private RemoteWorkflowExecutorImpl rwe;
@@ -48,6 +51,8 @@ public class RemoteWorkflowExecutorTest {
 
     @BeforeEach
     public void setup() {
+        clock = new ManualClock(Instant.now());
+
         workflow = new TestWorkflow();
 
         mockery = EasyMock.createControl();
@@ -59,7 +64,7 @@ public class RemoteWorkflowExecutorTest {
         config = new FluxCapacitorConfig();
         config.setSwfDomain("test");
 
-        rwe = new RemoteWorkflowExecutorImpl(new NoopMetricRecorderFactory(), workflowsByName, swf, config);
+        rwe = new RemoteWorkflowExecutorImpl(clock, new NoopMetricRecorderFactory(), workflowsByName, swf, config);
     }
 
     @Test


### PR DESCRIPTION
* `FluxCapacitor.getRemoteWorkflowExecutor` no longer directly takes SWF-specific inputs.
* SWF users can configure the remote workflow executor by providing a callback/lookup method to `FluxCapacitorConfig`.
* `flux-common` and `flux-testutils` no longer have a dependency on the AWS SDK.
* Removed `WorkflowStatusChecker.getSwfClient()` since it was only used by one remote workflow test, which can get the client another way. Regular users should not have been using it.
* Removed the swf endpoint override configuration from the integration tests, we only need the region name.

https://github.com/danielgmyers/flux-swf-client/issues/63