### PR TITLE
Implement identifier validation

### DIFF
--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -118,11 +118,6 @@
 
         <!--  config_misc -->
         <module name="ArrayTypeStyle"/>
-        <module name="AvoidEscapedUnicodeCharacters">
-            <property name="allowEscapesForControlCharacters" value="true"/>
-            <property name="allowByTailComment" value="true"/>
-            <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
         <module name="Indentation">
             <property name="basicOffset" value="4"/>
             <property name="braceAdjustment" value="0"/>

--- a/flux-swf/pom.xml
+++ b/flux-swf/pom.xml
@@ -22,6 +22,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/IdentifierValidation.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/IdentifierValidation.java
@@ -1,0 +1,180 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf;
+
+import java.util.regex.Pattern;
+
+import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.wf.Workflow;
+
+/**
+ * SWF has a service-side limit of 256 characters on the identifiers listed here unless otherwise noted.
+ *
+ * On startup, we register:
+ * 1) Domains, which is fully user-specified via config. We don't join this with anything.
+ * 2) WorkflowTypes, which we generate using the class names of the Workflow implementations.
+ * 3) ActivityTypes, which we generate by appending the WorkflowStep class names to their corresponding Workflow class names,
+ *    separated by a period. (This way, if a step is reused across workflows, it gets a different ActivityType for each workflow.)
+ *
+ * When polling for work, we use the current host's hostname as part of the poller's identity, along with an Flux-specified
+ * poller type, a small integer (between 0 and the thread pool size), and the user-specified task list being polled.
+ *
+ * When polling for work and when starting a new workflow execution, we give SWF a user-specified task list name.
+ *
+ * When starting a new workflow execution, we give SWF a user-specified workflow ID, and (possibly) a list of tags.
+ *
+ * When choosing the next step to execute during a workflow execution, we generate an activity id by combining the
+ * step name (without the workflow name), the retry number, and the partition ID (if applicable), joined with underscores:
+ *   "MyStep_0_MyPartitionId"
+ *
+ * Retry attempts won't be larger than 4166 in practice because SWF has a limit of 25000 events in a workflow's event history,
+ * and each attempt adds a minimum of six events to the event history. We will reserve four characters for the attempt count,
+ * and two characters for the underscores.
+ *
+ * Partition IDs are user-specified arbitrary strings. We store the user-specified value in the "control" field of
+ * the ScheduleActivityTaskDecision, which has a limit of 32768 characters, but for the activity ID we have two options:
+ * 1) Use the user-specified partition ID directly, which means imposing character and length limits on the user.
+ * 2) Hash the user-provided partition ID for the activity ID for uniqueness, so no limit is necessarily required.
+ *    If we use SHA-256 and convert the result to a hex string, we would only need to reserve 64 characters in the activityId.
+ *
+ * However, we also store the list of partition IDs in the "details" field of the RecordMarkerDecision, which has a length
+ * limit of 32768. We store other things in there as well. In practice, to keep the number of markers down to a minimum, we
+ * should impose a stricter limit on partition ID length than 32768. A length limit of 256, if used at maximum, would result in
+ * around 127 partition IDs per marker, but most users will not use anywhere near that maximum length for all partition IDs.
+ *
+ * Taken together, when a partition ID is provided, that means an activity ID is composed of:
+ *   "WorkflowStepClassName_1234_f6dc4d73b6ed26e764babebca8c27b9d3eb880131f1499b6745bdf60b68505ce"
+ * The most variable-length piece here is WorkflowStepClassName, so for activity ID purposes, its max length is 256-64-4-2 = 186.
+ *
+ * As noted above, however, workflow step class names are also used when registering ActivityTypes. Since that string has a
+ * maximum length of 256, and we use one period as a delimiter, if we split it evenly we need to limit both
+ * Workflow and WorkflowStep class implementations to a maximum class name length of 127 characters.
+ *
+ * While it is tempting to impose a smaller limit than that in order to discourage people from using excessively long
+ * class names, we need to concern ourselves here only with values that SWF will reject or that will interfere with Flux.
+ *
+ * Hostnames and task list names are similarly joined together with other data to generate the poller identity. Specifically,
+ * the identities look like this:
+ *   "hostname_taskTypeName-taskListName_threadNum"
+ * taskTypeName is a fixed string, either "decisionPoller" or "activityPoller", both of which are 14 characters long.
+ * threadNum is an integer, in practice it will be significantly less than 1000, but we can reserve 4 characters.
+ * If task list bucketing is enabled, then taskListName itself will be a composite of the user-specified task list name
+ * and an internally-generated bucket number. For safety we should reserve 5 characters for the extra data.
+ * This means we have (256 - 3 - 14 - 4 - 5) = 230 characters to split between hostname and the user's taskListName.
+ *
+ * We could split that evenly, but in practice hostnames are likely to be longer than task list names, so giving two thirds of the
+ * available space (i.e. 154 characters) to the hostname seems appropriate.
+ *
+ * In summary, we will enforce these length limits:
+ * * Domain name: 256
+ * * Workflow class implementation name: 127
+ * * WorkflowStep class implementation name: 127
+ * * Hostname: 154
+ * * Task list name: 76
+ * * Workflow execution ID: 256
+ * * Workflow execution tag: 256
+ * * Partition ID: 256
+ *
+ * These fields will also validate the content of the string against SWF's list of allowed characters:
+ * * Domain name
+ * * Workflow class implementation name
+ * * WorkflowStep class implementation name
+ * * Task list name
+ * * Workflow execution ID
+ *
+ * These fields allow any content within the prescribed length:
+ * * Hostname
+ * * Workflow execution tag
+ * * Partition ID
+ *
+ * See also com.danielgmyers.flux.poller.TaskNaming.
+ */
+public final class IdentifierValidation {
+
+    static final int MAX_DOMAIN_NAME_LENGTH = 256;
+    static final int MAX_WORKFLOW_CLASS_NAME_LENGTH = 127;
+    static final int MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH = 127;
+    static final int MAX_HOSTNAME_LENGTH = 154;
+    static final int MAX_TASK_LIST_NAME_LENGTH = 76;
+    static final int MAX_WORKFLOW_EXECUTION_ID_LENGTH = 256;
+    static final int MAX_WORKFLOW_EXECUTION_TAG_LENGTH = 256;
+    static final int MAX_PARTITION_ID_LENGTH = 256;
+
+    private static final Pattern INVALID_CHARACTERS = Pattern.compile("[:/|\u0000-\u001f\u007f-\u009f]+");
+
+    private IdentifierValidation() {}
+
+    public static void validateDomain(String domain) {
+        validate("Domains", domain, MAX_DOMAIN_NAME_LENGTH, true);
+    }
+
+    public static void validateWorkflowName(Class<? extends Workflow> clazz) {
+        validate("Workflow class names", TaskNaming.workflowName(clazz), MAX_WORKFLOW_CLASS_NAME_LENGTH, true);
+    }
+
+    public static void validateStepName(Class<? extends WorkflowStep> clazz) {
+        validate("WorkflowStep class names", TaskNaming.stepName(clazz), MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH, true);
+    }
+
+    public static void validateHostname(String hostname) {
+        validate("Hostnames", hostname, MAX_HOSTNAME_LENGTH, false);
+    }
+
+    public static void validateTaskListName(String taskListName) {
+        validate("Task list names", taskListName, MAX_TASK_LIST_NAME_LENGTH, true);
+    }
+
+    public static void validateWorkflowExecutionId(String executionId) {
+        validate("Workflow Execution IDs", executionId, MAX_WORKFLOW_EXECUTION_ID_LENGTH, true);
+    }
+
+    public static void validateWorkflowExecutionTag(String executionTag) {
+        validate("Workflow Execution Tags", executionTag, MAX_WORKFLOW_EXECUTION_TAG_LENGTH, false);
+    }
+
+    public static void validatePartitionId(String partitionId) {
+        validate("Partition IDs", partitionId, MAX_PARTITION_ID_LENGTH, false);
+    }
+
+    /**
+     * For all the fields that limit input characters, SWF provides this description:
+     *
+     * The specified string must not contain a : (colon), / (slash), | (vertical bar),
+     * or any control characters (\u0000-\u001f | \u007f-\u009f). Also, it must not be the literal string "arn".
+     *
+     * That last bit is weird, but the SWF API does in fact reject that input.
+     *
+     * Package-private for testing.
+     */
+    static void validate(String description, String inputToValidate, int max, boolean enforceCharacterConstraints) {
+        if (inputToValidate == null || inputToValidate.isEmpty()) {
+            throw new IllegalArgumentException(description + " must contain at least one character.");
+        }
+        if (inputToValidate.length() > max) {
+            throw new IllegalArgumentException(description + " must not be longer than " + max + " characters.");
+        }
+        if (enforceCharacterConstraints) {
+            if (INVALID_CHARACTERS.matcher(inputToValidate).find()) {
+                throw new IllegalArgumentException(description + " must not contain not contain a : (colon), / (slash),"
+                                       + " | (vertical bar), or any control characters (\\u0000-\\u001f | \\u007f-\\u009f).");
+            } else if ("arn".equals(inputToValidate)) {
+                throw new IllegalArgumentException(description + " must not be the literal string 'arn'.");
+            }
+        }
+    }
+}

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/IdentifierValidationTest.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/IdentifierValidationTest.java
@@ -1,0 +1,195 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.flux.wf.graph.WorkflowGraph;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class IdentifierValidationTest {
+
+    private static String invalidCharacters;
+
+    @BeforeAll
+    public static void setup() {
+        StringBuilder sb = new StringBuilder();
+        for (char c = '\u0000'; c <= '\u001f'; c++) {
+            sb.append(c);
+        }
+        for (char c = '\u007f'; c <= '\u009f'; c++) {
+            sb.append(c);
+        }
+        sb.append(':');
+        sb.append('/');
+        sb.append('|');
+        invalidCharacters = sb.toString();
+    }
+
+    @Test
+    public void testDomain() {
+        doCommonTests(IdentifierValidation::validateDomain, IdentifierValidation.MAX_DOMAIN_NAME_LENGTH, false);
+    }
+
+    @Test
+    public void testTaskListName() {
+        doCommonTests(IdentifierValidation::validateTaskListName, IdentifierValidation.MAX_TASK_LIST_NAME_LENGTH, false);
+    }
+
+    @Test
+    public void testWorkflowExecutionId() {
+        doCommonTests(IdentifierValidation::validateWorkflowExecutionId, IdentifierValidation.MAX_WORKFLOW_EXECUTION_ID_LENGTH, false);
+    }
+
+    @Test
+    public void testHostname() {
+        doCommonTests(IdentifierValidation::validateHostname, IdentifierValidation.MAX_HOSTNAME_LENGTH, true);
+    }
+
+    @Test
+    public void testWorkflowExecutionTag() {
+        doCommonTests(IdentifierValidation::validateWorkflowExecutionTag, IdentifierValidation.MAX_WORKFLOW_EXECUTION_TAG_LENGTH, true);
+    }
+
+    @Test
+    public void testPartitionId() {
+        doCommonTests(IdentifierValidation::validatePartitionId, IdentifierValidation.MAX_PARTITION_ID_LENGTH, true);
+    }
+
+    public static class TestWorkflowWithValidClassName implements Workflow {
+        // implementation doesn't need to be valid for this test
+        @Override
+        public WorkflowGraph getGraph() {
+            return null;
+        }
+    }
+
+    public static class TestWorkflowWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInRealCodeNoMatterHowWideYourMonitorIs implements Workflow {
+        // implementation doesn't need to be valid for this test
+        @Override
+        public WorkflowGraph getGraph() {
+            return null;
+        }
+    }
+
+    public static class TestWorkflowWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely implements Workflow {
+        // implementation doesn't need to be valid for this test
+        @Override
+        public WorkflowGraph getGraph() {
+            return null;
+        }
+    }
+
+    @Test
+    public void testWorkflowClassName() {
+        // these two checks just ensure the test will break if the max name length constant or the class names get changed.
+        Assertions.assertEquals(IdentifierValidation.MAX_WORKFLOW_CLASS_NAME_LENGTH, TestWorkflowWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInRealCodeNoMatterHowWideYourMonitorIs.class.getSimpleName().length());
+        Assertions.assertTrue(IdentifierValidation.MAX_WORKFLOW_CLASS_NAME_LENGTH < TestWorkflowWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class.getSimpleName().length());
+
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateWorkflowName(TestWorkflowWithValidClassName.class));
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateWorkflowName(TestWorkflowWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInRealCodeNoMatterHowWideYourMonitorIs.class));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                                () -> IdentifierValidation.validateWorkflowName(TestWorkflowWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class));
+    }
+
+    public static class TestWorkflowStepWithValidClassName implements WorkflowStep {
+        // implementation doesn't need to be valid for this test
+    }
+
+    public static class TestWorkflowStepWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInCodeNoMatterHowWideYourMonitorIs implements WorkflowStep {
+        // implementation doesn't need to be valid for this test
+    }
+
+    public static class TestWorkflowStepWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely implements WorkflowStep {
+        // implementation doesn't need to be valid for this test
+    }
+
+    @Test
+    public void testWorkflowStepClassName() {
+        // these two checks just ensure the test will break if the max name length constant or the class names get changed.
+        Assertions.assertEquals(IdentifierValidation.MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH, TestWorkflowWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInRealCodeNoMatterHowWideYourMonitorIs.class.getSimpleName().length());
+        Assertions.assertTrue(IdentifierValidation.MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH < TestWorkflowWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class.getSimpleName().length());
+
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateStepName(TestWorkflowStepWithValidClassName.class));
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateStepName(TestWorkflowStepWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInCodeNoMatterHowWideYourMonitorIs.class));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                                () -> IdentifierValidation.validateStepName(TestWorkflowStepWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class));
+    }
+
+    @Test
+    public void testInternalValidate_RejectsEachInvalidCharacter() {
+        for (int i = 0; i < invalidCharacters.length(); i++) {
+            String id = invalidCharacters.substring(i, i+1);
+            Assertions.assertThrows(IllegalArgumentException.class,
+                                    () -> IdentifierValidation.validate("test", id, 256, true));
+        }
+    }
+    @Test
+    public void testInternalValidate_AllowsEachInvalidCharacterIfFlagDisabled() {
+        for (int i = 0; i < invalidCharacters.length(); i++) {
+            String id = invalidCharacters.substring(i, i+1);
+            Assertions.assertDoesNotThrow(() -> IdentifierValidation.validate("test", id, 256, false));
+        }
+    }
+
+    private void doCommonTests(Consumer<String> validationMethod, int maxLength, boolean allowInvalidCharacters) {
+        // first verify that it accepts valid identifiers
+        String validId = generateString(maxLength, allowInvalidCharacters);
+        Assertions.assertDoesNotThrow(() -> validationMethod.accept(validId));
+
+        // verify that null/empty are disallowed
+        Assertions.assertThrows(IllegalArgumentException.class,
+                                () -> validationMethod.accept(null));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                                () -> validationMethod.accept(""));
+
+        // if invalid characters are disallowed, verify they are rejected
+        if (!allowInvalidCharacters) {
+            String id = generateString(maxLength, true);
+            Assertions.assertThrows(IllegalArgumentException.class,
+                                    () -> validationMethod.accept(id));
+        }
+
+        // verify that too-long identifiers are rejected
+        String tooLongId = generateString(maxLength+1, allowInvalidCharacters);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                                () -> validationMethod.accept(tooLongId));
+    }
+
+    private String generateString(int length, boolean includeInvalidCharacters) {
+        Assertions.assertTrue(length > 0);
+
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            // if we're supposed to include invalid characters, we'll grab one from this list:
+            // \u0000-\u001f\u007f-\u009f:/|
+            // ... for every other character, starting with the first.
+            if (includeInvalidCharacters && i % 2 == 0) {
+                int p = ThreadLocalRandom.current().nextInt(invalidCharacters.length());
+                result.append(invalidCharacters.charAt(p));
+            } else {
+                result.append("a");
+            }
+        }
+        return result.toString();
+    }
+}

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/WorkflowStateTest.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/WorkflowStateTest.java
@@ -19,7 +19,6 @@ package com.danielgmyers.flux.clients.swf.poller;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -102,7 +101,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_WorkflowStarted() {
+    public void testBuild_WorkflowStarted() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -132,7 +131,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_ActivityCompleted_Success() {
+    public void testBuild_ActivityCompleted_Success() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -179,7 +178,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_ActivityCompleted_Failed() {
+    public void testBuild_ActivityCompleted_Failed() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -225,7 +224,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_ActivityCompleted_CustomResultCode() {
+    public void testBuild_ActivityCompleted_CustomResultCode() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -334,11 +333,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_BothPartitionActivitiesRetried() {
+    public void testBuild_PartitionedStep_BothPartitionActivitiesRetried() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -351,6 +350,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -389,11 +392,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_OnePartitionSucceededAndOneRetried() {
+    public void testBuild_PartitionedStep_OnePartitionSucceededAndOneRetried() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -406,6 +409,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -444,11 +451,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_OnePartitionFailedAndOneRetried() {
+    public void testBuild_PartitionedStep_OnePartitionFailedAndOneRetried() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -461,6 +468,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -499,11 +510,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_FirstPartitionSucceededAndSecondFailedToSchedule() {
+    public void testBuild_PartitionedStep_FirstPartitionSucceededAndSecondFailedToSchedule() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -516,6 +527,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -556,11 +571,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_FirstFailedToScheduleAndSecondSucceeded() {
+    public void testBuild_PartitionedStep_FirstFailedToScheduleAndSecondSucceeded() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -573,6 +588,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.recordScheduleAttemptFailed("p1");
@@ -612,11 +631,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_BothPartitionsFailedToSchedule() {
+    public void testBuild_PartitionedStep_BothPartitionsFailedToSchedule() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String firstStepName = TaskNaming.activityName(workflow, TestStepOne.class);
@@ -630,6 +649,10 @@ public class WorkflowStateTest {
 
         Instant stepOneEndTime = clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         clock.forward(Duration.ofMillis(100));
         history.recordScheduleAttemptFailed("p1");
@@ -652,23 +675,17 @@ public class WorkflowStateTest {
         Assertions.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
         Assertions.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
 
+        // It should look like we never tried to schedule this step at all yet
         Assertions.assertNotNull(ws.getLatestPartitionStates(partitionedStepName));
-        Assertions.assertFalse(ws.getLatestPartitionStates(partitionedStepName).isEmpty());
-        Assertions.assertEquals(2, ws.getLatestPartitionStates(partitionedStepName).size());
-
-        Assertions.assertTrue(ws.getLatestPartitionStates(partitionedStepName).containsKey("p1"));
-        Assertions.assertNull(ws.getLatestPartitionStates(partitionedStepName).get("p1"));
-
-        Assertions.assertTrue(ws.getLatestPartitionStates(partitionedStepName).containsKey("p2"));
-        Assertions.assertNull(ws.getLatestPartitionStates(partitionedStepName).get("p2"));
+        Assertions.assertTrue(ws.getLatestPartitionStates(partitionedStepName).isEmpty());
     }
 
     @Test
-    public void testBuild_PartitionedStep_BothPartitionsCompleted_BothSucceeded() {
+    public void testBuild_PartitionedStep_BothPartitionsCompleted_BothSucceeded() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -681,6 +698,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -727,11 +748,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_BothPartitionsCompleted_OneFailed_OneSucceeded() {
+    public void testBuild_PartitionedStep_BothPartitionsCompleted_OneFailed_OneSucceeded() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -744,6 +765,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -790,11 +815,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_BothPartitionsCompletedAfterMultipleAttempts() {
+    public void testBuild_PartitionedStep_BothPartitionsCompletedAfterMultipleAttempts() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -807,6 +832,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -893,11 +922,11 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_PartitionedStep_BothPartitionsCompletedAfterMultipleAttempts_OneFailed_OneSucceeded() {
+    public void testBuild_PartitionedStep_BothPartitionsCompletedAfterMultipleAttempts_OneFailed_OneSucceeded() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
-        List<String> partitionIds = Arrays.asList("p1", "p2");
+        Set<String> partitionIds = Set.of("p1", "p2");
 
         Workflow workflow = new TestWorkflowWithPartitionedStep(partitionIds);
         String partitionedStepName = TaskNaming.activityName(workflow, TestPartitionedStep.class);
@@ -910,6 +939,10 @@ public class WorkflowStateTest {
 
         clock.forward(Duration.ofMillis(100));
         history.recordActivityResult(StepResult.success());
+
+        history.recordPartitionMetadataMarkers(clock.forward(Duration.ofMillis(100)),
+                                               TaskNaming.stepName(TestPartitionedStep.class),
+                                               PartitionIdGeneratorResult.create(partitionIds));
 
         Instant stepTwoStartTime = clock.forward(Duration.ofMillis(100));
         history.scheduleStepAttempt("p1");
@@ -995,7 +1028,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_ActivityTimedOut_Retry() {
+    public void testBuild_ActivityTimedOut_Retry() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1036,7 +1069,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_ActivityCanceled_Retry() {
+    public void testBuild_ActivityCanceled_Retry() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1077,7 +1110,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_MultipleStepAttemptsPresent_Success() {
+    public void testBuild_MultipleStepAttemptsPresent_Success() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1154,7 +1187,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_UsesMostRecentStepWhenMultipleStepsInHistory_Success() {
+    public void testBuild_UsesMostRecentStepWhenMultipleStepsInHistory_Success() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1205,7 +1238,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsOpenTimer() {
+    public void testBuild_DetectsOpenTimer() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1251,7 +1284,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsTimerFired() {
+    public void testBuild_DetectsTimerFired() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1299,7 +1332,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsTimerCancelled() {
+    public void testBuild_DetectsTimerCancelled() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1346,7 +1379,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsTimerThatWasCancelledAndRestarted() {
+    public void testBuild_DetectsTimerThatWasCancelledAndRestarted() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1396,7 +1429,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsTimerThatWasCancelledAndRestartedAndFiredNormally() {
+    public void testBuild_DetectsTimerThatWasCancelledAndRestartedAndFiredNormally() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1863,7 +1896,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_IgnoresInvalidSignalData() {
+    public void testBuild_IgnoresInvalidSignalData() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1911,7 +1944,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsWorkflowCancelRequest() {
+    public void testBuild_DetectsWorkflowCancelRequest() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1945,7 +1978,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsWorkflowCancelRequest_FirstStepInProgress() {
+    public void testBuild_DetectsWorkflowCancelRequest_FirstStepInProgress() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -1982,7 +2015,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsWorkflowCompletion_ExecutionCanceled() {
+    public void testBuild_DetectsWorkflowCompletion_ExecutionCanceled() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -2019,7 +2052,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsWorkflowCompletion_ExecutionCompleted() {
+    public void testBuild_DetectsWorkflowCompletion_ExecutionCompleted() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -2076,7 +2109,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsWorkflowCompletion_ExecutionFailed() {
+    public void testBuild_DetectsWorkflowCompletion_ExecutionFailed() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -2133,7 +2166,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsWorkflowCompletion_ExecutionTerminated() {
+    public void testBuild_DetectsWorkflowCompletion_ExecutionTerminated() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -2167,7 +2200,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testBuild_DetectsWorkflowCompletion_ExecutionTimedOut() {
+    public void testBuild_DetectsWorkflowCompletion_ExecutionTimedOut() throws JsonProcessingException {
         Map<String, String> input = new HashMap<>();
         input.put("foo", "bar");
 
@@ -2383,7 +2416,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testGetPartitionMetadata_NoMetadataMarker() {
+    public void testGetPartitionMetadata_NoMetadataMarker() throws JsonProcessingException {
         Set<String> partitionIds = new HashSet<>();
         partitionIds.add("p1");
         partitionIds.add("p2");
@@ -2472,7 +2505,7 @@ public class WorkflowStateTest {
     }
 
     @Test
-    public void testGetPartitionMetadata_InvalidMetadataMarker() {
+    public void testGetPartitionMetadata_InvalidMetadataMarker() throws JsonProcessingException {
         Set<String> partitionIds = new HashSet<>();
         partitionIds.add("p1");
         partitionIds.add("p2");

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <properties>
         <flux.version>${project.version}</flux.version>
         <awssdk.version>2.17.293</awssdk.version>
+        <commons-codec.version>1.15</commons-codec.version>
         <jackson.version>2.14.0-rc2</jackson.version>
         <slf4j.version>2.0.3</slf4j.version>
         <metricrecorder.version>1.0.0</metricrecorder.version>


### PR DESCRIPTION
Implement identifier validation for several identifiers we either pass directly to SWF, or use to synthesize an identifier passed to SWF.

Switch to a hash of the partitionId in activityIds so that partition IDs can contain arbitrary data (e.g. ARNs).

https://github.com/danielgmyers/flux-swf-client/issues/37