### PR TITLE
Make partition ID hashing toggleable. Off by default.

### DIFF
--- a/flux-common/src/main/java/com/danielgmyers/flux/poller/TaskNaming.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/poller/TaskNaming.java
@@ -123,7 +123,7 @@ public final class TaskNaming {
     }
 
     /**
-     * Given a full partition metadata marker name (as produced by {@link #activityName}),
+     * Given a full partition metadata marker name (as produced by {@link #partitionMetadataMarkerName}),
      * extracts the step name.
      */
     public static String extractPartitionMetadataMarkerStepName(String metadataMarkerName) {
@@ -135,7 +135,7 @@ public final class TaskNaming {
     }
 
     /**
-     * Given a full partition metadata marker name (as produced by {@link #activityName}),
+     * Given a full partition metadata marker name (as produced by {@link #partitionMetadataMarkerName}),
      * extracts the marker subset id number.
      */
     public static Long extractPartitionMetadataMarkerSubsetId(String metadataMarkerName) {
@@ -147,7 +147,7 @@ public final class TaskNaming {
     }
 
     /**
-     * Given a full partition metadata marker name (as produced by {@link #activityName}),
+     * Given a full partition metadata marker name (as produced by {@link #partitionMetadataMarkerName}),
      * extracts the marker count.
      */
     public static Long extractPartitionMetadataMarkerCount(String metadataMarkerName) {

--- a/flux-swf-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/PartitionedWorkflowWithIdHashingTests.java
+++ b/flux-swf-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/PartitionedWorkflowWithIdHashingTests.java
@@ -1,0 +1,30 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.tests;
+
+import com.danielgmyers.flux.clients.swf.FluxCapacitorConfig;
+
+/**
+ * This should run the same tests as PartitionedWorkflowTests, except it enables partition ID hashing.
+ */
+public class PartitionedWorkflowWithIdHashingTests extends PartitionedWorkflowTests {
+
+    @Override
+    protected void updateFluxCapacitorConfig(FluxCapacitorConfig config) {
+        config.setEnablePartitionIdHashing(true);
+    }
+}

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorConfig.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorConfig.java
@@ -35,6 +35,7 @@ public class FluxCapacitorConfig {
     private ClientOverrideConfiguration clientOverrideConfiguration;
     private final Map<String, TaskListConfig> taskListConfigs = new HashMap<>();
     private Boolean automaticallyTagExecutionsWithTaskList;
+    private Boolean enablePartitionIdHashing;
     private Function<String, RemoteSwfClientConfig> remoteSwfClientConfigProvider;
 
     public String getAwsRegion() {
@@ -169,6 +170,21 @@ public class FluxCapacitorConfig {
 
     public Boolean getAutomaticallyTagExecutionsWithTaskList() {
         return automaticallyTagExecutionsWithTaskList;
+    }
+
+    /**
+     * Controls whether Flux will use a hash of the user-provided partition IDs when generating activity IDs.
+     * If not specified, this flag is disabled.
+     *
+     * If disabled, user-provided partition IDs will be limited to a length of 123 characters, and may not contain ":", "/", or "|".
+     * If enabled, user-provided partition IDs will be limited to a length of 256 characters, with no content constraints.
+     */
+    public void setEnablePartitionIdHashing(Boolean enablePartitionIdHashing) {
+        this.enablePartitionIdHashing = enablePartitionIdHashing;
+    }
+
+    public boolean getEnablePartitionIdHashing() {
+        return (enablePartitionIdHashing != null ? enablePartitionIdHashing : false);
     }
 
     /**

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorImpl.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorImpl.java
@@ -560,10 +560,6 @@ public final class FluxCapacitorImpl implements FluxCapacitor {
         activityTaskPollerThreadsPerTaskList = new HashMap<>();
         workerThreadsPerTaskList = new HashMap<>();
 
-        final double exponentialBackoffCoefficient = (config.getExponentialBackoffBase() != null
-                                                        ? config.getExponentialBackoffBase()
-                                                        : DEFAULT_EXPONENTIAL_BACKOFF_BASE);
-
         Set<String> baseTaskLists = workflowsByName.values().stream().map(Workflow::taskList).collect(Collectors.toSet());
         Set<String> bucketedTaskLists = new HashSet<>(baseTaskLists);
         for (String taskList : baseTaskLists) {
@@ -583,8 +579,7 @@ public final class FluxCapacitorImpl implements FluxCapacitor {
 
             poolSize = config.getTaskListConfig(taskList).getDecisionTaskPollerThreadCount();
             ScheduledExecutorService service = createExecutorService(taskList, hostname, "decisionPoller", poolSize,
-                deciderName -> new DecisionTaskPoller(metricsFactory, swf, workflowDomain, taskList, deciderName,
-                                                      exponentialBackoffCoefficient, workflowsByName,
+                deciderName -> new DecisionTaskPoller(metricsFactory, swf, config, taskList, deciderName, workflowsByName,
                                                       activitiesByName, deciderThreadsPerTaskList.get(taskList),
                                                       clock));
             decisionTaskPollerThreadsPerTaskList.put(taskList, service);

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/ActivityTaskPoller.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/ActivityTaskPoller.java
@@ -91,7 +91,7 @@ public class ActivityTaskPoller implements Runnable {
         this.domain = workflowDomain;
         this.taskListName = taskListName;
 
-        if (identity == null || identity.length() <= 0 || identity.length() > 256) {
+        if (identity == null || identity.isEmpty() || identity.length() > 256) {
             throw new IllegalArgumentException("Invalid identity for task poller, must be 1-256 characters: " + identity);
         }
         this.identity = identity;
@@ -120,7 +120,7 @@ public class ActivityTaskPoller implements Runnable {
     }
 
     private Runnable pollForActivityTask(MetricRecorder metrics) {
-        try {
+        try (metrics) {
             Duration waitTime = metrics.endDuration(WORKER_THREAD_AVAILABILITY_WAIT_TIME_METRIC_NAME);
             // emit the wait time metric again, under this poller's task list name.
             metrics.addDuration(WORKER_THREAD_AVAILABILITY_WAIT_TIME_METRIC_NAME + "." + taskListName, waitTime);
@@ -162,8 +162,6 @@ public class ActivityTaskPoller implements Runnable {
         } catch (Throwable e) {
             log.warn("Got an unexpected exception when polling for an activity task.", e);
             throw e;
-        } finally {
-            metrics.close();
         }
     }
 

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/IdentifierValidationTest.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/IdentifierValidationTest.java
@@ -48,31 +48,41 @@ public class IdentifierValidationTest {
     @Test
     public void testDomain() {
         doCommonTests(IdentifierValidation::validateDomain, IdentifierValidation.MAX_DOMAIN_NAME_LENGTH, false);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> IdentifierValidation.validateDomain("arn"));
     }
 
     @Test
     public void testTaskListName() {
         doCommonTests(IdentifierValidation::validateTaskListName, IdentifierValidation.MAX_TASK_LIST_NAME_LENGTH, false);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> IdentifierValidation.validateTaskListName("arn"));
     }
 
     @Test
     public void testWorkflowExecutionId() {
         doCommonTests(IdentifierValidation::validateWorkflowExecutionId, IdentifierValidation.MAX_WORKFLOW_EXECUTION_ID_LENGTH, false);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> IdentifierValidation.validateWorkflowExecutionId("arn"));
     }
 
     @Test
     public void testHostname() {
         doCommonTests(IdentifierValidation::validateHostname, IdentifierValidation.MAX_HOSTNAME_LENGTH, true);
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateHostname("arn"));
     }
 
     @Test
     public void testWorkflowExecutionTag() {
         doCommonTests(IdentifierValidation::validateWorkflowExecutionTag, IdentifierValidation.MAX_WORKFLOW_EXECUTION_TAG_LENGTH, true);
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateWorkflowExecutionTag("arn"));
     }
 
     @Test
     public void testPartitionId() {
-        doCommonTests(IdentifierValidation::validatePartitionId, IdentifierValidation.MAX_PARTITION_ID_LENGTH, true);
+        doCommonTests((s) -> IdentifierValidation.validatePartitionId(s, true), IdentifierValidation.MAX_PARTITION_ID_LENGTH_HASHING_ENABLED, true);
+        doCommonTests((s) -> IdentifierValidation.validatePartitionId(s, false), IdentifierValidation.MAX_PARTITION_ID_LENGTH_HASHING_DISABLED, false);
+
+        // "arn" should be allowed either way, even though invalid characters aren't allowed with hashing disabled.
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validatePartitionId("arn", true));
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validatePartitionId("arn", false));
     }
 
     public static class TestWorkflowWithValidClassName implements Workflow {
@@ -140,14 +150,14 @@ public class IdentifierValidationTest {
         for (int i = 0; i < invalidCharacters.length(); i++) {
             String id = invalidCharacters.substring(i, i+1);
             Assertions.assertThrows(IllegalArgumentException.class,
-                                    () -> IdentifierValidation.validate("test", id, 256, true));
+                                    () -> IdentifierValidation.validate("test", id, 256, true, true));
         }
     }
     @Test
     public void testInternalValidate_AllowsEachInvalidCharacterIfFlagDisabled() {
         for (int i = 0; i < invalidCharacters.length(); i++) {
             String id = invalidCharacters.substring(i, i+1);
-            Assertions.assertDoesNotThrow(() -> IdentifierValidation.validate("test", id, 256, false));
+            Assertions.assertDoesNotThrow(() -> IdentifierValidation.validate("test", id, 256, false, false));
         }
     }
 


### PR DESCRIPTION
I also verified in the AWS Console that the new integration tests enable partition id hashing (and that the old tests don't).

https://github.com/danielgmyers/flux-swf-client/issues/103