### PR TITLE
Make execution context a proper nested json map.

### DIFF
--- a/MIGRATION_TO_2.1.md
+++ b/MIGRATION_TO_2.1.md
@@ -72,6 +72,35 @@ Flux will attempt to properly handle any partitioned workflow steps that are run
 
 The `EnablePartitionIdHashing` feature is disabled by default in 2.1.0.
 
+Execution context changes
+----
+
+As discussed in [SIGNALS.md](./SIGNALS.md), Flux populates the workflow's execution context (accessible via the `latestExecutionContext` field in the response to the SWF `DescribeWorkflowExecution` API) with metadata intended to assist in using the `ForceResult` signal safely.
+
+Prior to 2.1.0, the execution context contained a JSON-formatted map with two string values, both of which were themselves json values encoded as strings. For example:
+
+```json
+{
+  "_nextStepName": "\"EatSandwich\"",
+  "_nextStepSupportedResultCodes": "{\"_succeed\":\"DrinkWater\",\"_fail\":\"ThrowAwayBadSandwich\"}"
+}
+```
+
+As of 2.1.0, the format of the execution context has been simplified. A version number field has been added to allow you to verify that you are parsing the context correctly, and the values of the other fields are no longer json-encoded strings. The context above would now look like this:
+
+```json
+{
+  "fluxMetadataVersion": 2,
+  "_nextStepName": "EatSandwich",
+  "_nextStepSupportedResultCodes": {
+    "_succeed": "DrinkWater",
+    "_fail": "ThrowAwayBadSandwich"
+  }
+}
+```
+
+If you currently have tools that parse the execution context, you will need to update them to support both formats during the 2.1.0 upgrade, and then remove the old parsing logic once the upgrade is complete.
+
 Input validation changes
 ----
 

--- a/SIGNALS.md
+++ b/SIGNALS.md
@@ -3,7 +3,7 @@ Flux supports using SWF's workflow signaling mechanism to affect the behavior of
 
 To send a signal, the `SignalName` field in the SWF `SignalWorkflowExecution` request should be the name of the signal exactly as documented below, and the input to the signal should be a map of input attributes, in json format, containing the attributes required for that signal. Since these signals are typically sent from a UI (such as an operational console or the AWS Management Console), or via CLI commands, and since these signals are not normally useful except for extraordinary operational needs, the FluxCapacitor interface does not provide a way to send these signals from within your application.
 
-All signals require, as one of their inputs, a field named `activityId`, which should match the activity id of the *next* execution of the step. This will match the id of the open retry timer. For example, if a step is named `EatSandwich`, and the fifth retry of the step is scheduled, there will be an open timer with the id `EatSandwich_5`, and when that step actually executes again, that activity's id will be `EatSandwich_5`.
+All signals require, as one of their inputs, a field named `activityId`, which should match the activity id of the _next_ execution of the step. This will match the id of the open retry timer. For example, if a step is named `EatSandwich`, and the fifth retry of the step is scheduled, there will be an open timer with the id `EatSandwich_5`, and when that step actually executes again, that activity's id will be `EatSandwich_5`.
 
 Delay Retry
 -----------
@@ -37,9 +37,9 @@ Example input:
 Force Result
 ------------
 
-This signal tells flux to cancel the current retry timer and pretend the step completed with the specified result code. Note that if your graph does not define a transition for that result code, your workflow will get stuck; to fix this, send another ForceResult signal with the same activityId containing a result code that your graph //does// define a transition for.
+This signal tells flux to cancel the current retry timer and pretend the step completed with the specified result code. Note that if your graph does not define a transition for that result code, your workflow will get stuck; to fix this, send another ForceResult signal with the same activityId containing a result code that your graph _does_ define a transition for.
 
-The two default result codes are `_succeed` and `_fail`, but you may specify any result code defined by your workflow graph.
+The two default result codes are `_succeed` and `_fail`, but you may specify any result code defined by your workflow graph (except partitioned steps, which only support the two default codes).
 
 This is most useful for forcing a workflow into a rollback path.
 
@@ -61,27 +61,19 @@ The execution context will be a json object as follows:
 
 ```json
 {
-  "_nextStepName": "\"EatSandwich\"",
-  "_nextStepSupportedResultCodes": "<result code map>"
+  "fluxMetadataVersion": 2,
+  "_nextStepName": "EatSandwich",
+  "_nextStepSupportedResultCodes": {
+    "_succeed": "DrinkWater",
+    "_fail": "ThrowAwayBadSandwich"
+  }
 }
 ```
 
-`_nextStepName` indicates which step the workflow will run next (keeping in mind that this value is set at the same time as the next step is scheduled). For implementation reasons, the string is double-encoded.
+The `fluxMetadataVersion` field is provided by Flux to help you know how to parse the execution context. This will typically only be useful while upgrading Flux when the metadata format has changed, but you should check this value in your tooling to be sure you notice if the format changes.
 
-`_nextStepSupportedResultCodes` is itself a json object (encoded into a string) that (when decoded) looks like this:
+`_nextStepName` indicates which step the workflow will run next (keeping in mind that this value is set at the same time as the next step is scheduled).
 
-```json
-{
-  "_succeed": "DrinkWater",
-  "_fail": "ThrowAwayBadSandwich"
-}
-``` 
+For each result code supported by that step, `_nextStepSupportedResultCodes` indicates which workflow step will be executed after this one if it completes with that result code.
 
-All together, the execution context for this example would be:
-
-```json
-{
-  "_nextStepName": "\"EatSandwich\"",
-  "_nextStepSupportedResultCodes": "{\"_succeed\":\"DrinkWater\",\"_fail\":\"ThrowAwayBadSandwich\"}"
-}
-```
+Note that if the result code map contains a mapping for the special `_always` result code, then the indicated step will always be executed, regardless of the actual result code returned by the step or specified in a signal. 

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/ExecutionContextMetadata.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/ExecutionContextMetadata.java
@@ -1,0 +1,120 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.poller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.wf.graph.WorkflowGraph;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphNode;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility class for writing the user-facing execution context.
+ *
+ * Package-private for access in tests.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+final class ExecutionContextMetadata {
+
+    static final String KEY_METADATA_VERSION = "fluxMetadataVersion";
+    static final String KEY_NEXT_STEP_NAME = "_nextStepName";
+    static final String KEY_NEXT_STEP_RESULT_CODES = "_nextStepSupportedResultCodes";
+    static final String NEXT_STEP_RESULT_WORKFLOW_ENDS = "_closeWorkflow";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Description of the versions, just for future reference:
+     * 1 - Contains next step name and result codes but no version field. Attribute values are double-encoded.
+     * 2 - Values are now regular json string/map types, version field is explicitly included in the context.
+     *
+     * Note that since Flux never actually reads the execution context, this version is only provided for users
+     * to have a way to check that their parsing code will use the right logic during version upgrades;
+     * additionally, Flux doesn't need to know how to decode or handle previous versions.
+     *
+     * We should increment this if we rename an existing field or change its type or encoding format.
+     */
+    static final Long CURRENT_METADATA_VERSION = 2L;
+
+    @JsonProperty(value = KEY_METADATA_VERSION)
+    private Long metadataVersion = CURRENT_METADATA_VERSION;
+
+    @JsonProperty(value = KEY_NEXT_STEP_NAME)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String nextStepName;
+
+    @JsonProperty(value = KEY_NEXT_STEP_RESULT_CODES)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<String, String> resultCodeMap;
+
+    public Long getMetadataVersion() {
+        return metadataVersion;
+    }
+
+    public String getNextStepName() {
+        return nextStepName;
+    }
+
+    public void setNextStepName(String nextStepName) {
+        this.nextStepName = nextStepName;
+    }
+
+    public Map<String, String> getResultCodeMap() {
+        return resultCodeMap;
+    }
+
+    public void populateExecutionContext(Class<? extends WorkflowStep> nextStep, WorkflowGraph graph) {
+        nextStepName = nextStep.getSimpleName();
+        resultCodeMap = new HashMap<>();
+        WorkflowGraphNode node = graph.getNodes().get(nextStep);
+        for (Map.Entry<String, WorkflowGraphNode> entry : node.getNextStepsByResultCode().entrySet()) {
+            if (entry.getValue() == null) {
+                resultCodeMap.put(entry.getKey(), NEXT_STEP_RESULT_WORKFLOW_ENDS);
+            } else {
+                resultCodeMap.put(entry.getKey(), entry.getValue().getStep().getClass().getSimpleName());
+            }
+        }
+    }
+
+    /**
+     * If nextStepName and resultCodeMap are empty/null, this returns null, since there's no point
+     * populating context data in SWF if we don't have any.
+     */
+    public String encode() throws JsonProcessingException {
+        if (nextStepName == null && (resultCodeMap == null || resultCodeMap.isEmpty())) {
+            return null;
+        }
+        return MAPPER.writeValueAsString(this);
+    }
+
+    /**
+     * Flux itself never needs to decode the execution context since it's provided for user convenience;
+     * this method is only provided for testing purposes.
+     */
+    public static ExecutionContextMetadata decode(String encoded) throws JsonProcessingException {
+        if (encoded == null) {
+            return null;
+        }
+        return MAPPER.readValue(encoded, ExecutionContextMetadata.class);
+    }
+}

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/ExecutionContextMetadataTest.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/ExecutionContextMetadataTest.java
@@ -1,0 +1,161 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.poller;
+
+import com.danielgmyers.flux.step.StepApply;
+import com.danielgmyers.flux.step.StepResult;
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.flux.wf.graph.WorkflowGraph;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ExecutionContextMetadataTest {
+
+    public static class EatSandwich implements WorkflowStep {
+        @StepApply
+        public void doThing() {
+        }
+    }
+
+    public static class DrinkWater implements WorkflowStep {
+        @StepApply
+        public void doThing() {
+        }
+    }
+
+    public static class ThrowAwayBadSandwich implements WorkflowStep {
+        @StepApply
+        public void doThing() {
+        }
+    }
+
+    public static class TestWorkflow implements Workflow {
+        @Override
+        public WorkflowGraph getGraph() {
+            EatSandwich eat = new EatSandwich();
+            DrinkWater dw = new DrinkWater();
+            ThrowAwayBadSandwich tabs = new ThrowAwayBadSandwich();
+
+            WorkflowGraphBuilder builder = new WorkflowGraphBuilder(eat);
+            builder.successTransition(eat, dw);
+            builder.failTransition(eat, tabs);
+
+            builder.addStep(dw);
+            builder.alwaysClose(dw);
+
+            builder.addStep(tabs);
+            builder.alwaysClose(tabs);
+
+            return builder.build();
+        }
+    }
+
+    private static final String DELAY_EXIT_CONTEXT
+            = "{\"" + ExecutionContextMetadata.KEY_METADATA_VERSION + "\":" + ExecutionContextMetadata.CURRENT_METADATA_VERSION + "," +
+            "\"" + ExecutionContextMetadata.KEY_NEXT_STEP_NAME + "\":\"" + DecisionTaskPoller.DELAY_EXIT_TIMER_ID + "\"}";
+
+    private static final String EAT_SANDWICH_EXPECTED_CONTEXT
+            = "{\"" + ExecutionContextMetadata.KEY_METADATA_VERSION + "\":" + ExecutionContextMetadata.CURRENT_METADATA_VERSION + "," +
+               "\"" + ExecutionContextMetadata.KEY_NEXT_STEP_NAME + "\":\"" + EatSandwich.class.getSimpleName() + "\"," +
+               "\"" + ExecutionContextMetadata.KEY_NEXT_STEP_RESULT_CODES + "\":{" +
+                  "\"" + StepResult.SUCCEED_RESULT_CODE + "\":\"" + DrinkWater.class.getSimpleName() + "\"," +
+                  "\"" + StepResult.FAIL_RESULT_CODE + "\":\"" + ThrowAwayBadSandwich.class.getSimpleName() + "\"" +
+              "}}";
+
+    private static final String DRINK_WATER_EXPECTED_CONTEXT
+            = "{\"" + ExecutionContextMetadata.KEY_METADATA_VERSION + "\":" + ExecutionContextMetadata.CURRENT_METADATA_VERSION + "," +
+               "\"" + ExecutionContextMetadata.KEY_NEXT_STEP_NAME + "\":\"" + DrinkWater.class.getSimpleName() + "\"," +
+               "\"" + ExecutionContextMetadata.KEY_NEXT_STEP_RESULT_CODES + "\":{" +
+                  "\"" + StepResult.ALWAYS_RESULT_CODE + "\":\"" + ExecutionContextMetadata.NEXT_STEP_RESULT_WORKFLOW_ENDS + "\"" +
+            "}}";
+
+    @Test
+    public void testEncodeEmptyContext() throws JsonProcessingException {
+        ExecutionContextMetadata ecm = new ExecutionContextMetadata();
+        Assertions.assertNull(ecm.encode());
+    }
+
+    @Test
+    public void testEncodeContextWithOnlyNextStepName() throws JsonProcessingException {
+        ExecutionContextMetadata ecm = new ExecutionContextMetadata();
+        ecm.setNextStepName(DecisionTaskPoller.DELAY_EXIT_TIMER_ID);
+        Assertions.assertEquals(DELAY_EXIT_CONTEXT, ecm.encode());
+    }
+
+    @Test
+    public void testEncodeContextWithResultCodeMap() throws JsonProcessingException {
+        TestWorkflow wf = new TestWorkflow();
+
+        ExecutionContextMetadata ecm = new ExecutionContextMetadata();
+        ecm.populateExecutionContext(EatSandwich.class, wf.getGraph());
+
+        Assertions.assertEquals(EAT_SANDWICH_EXPECTED_CONTEXT, ecm.encode());
+    }
+
+    @Test
+    public void testEncodeContextWithResultCodeMapWhenWorkflowEnds() throws JsonProcessingException {
+        TestWorkflow wf = new TestWorkflow();
+
+        ExecutionContextMetadata ecm = new ExecutionContextMetadata();
+        ecm.populateExecutionContext(DrinkWater.class, wf.getGraph());
+
+        Assertions.assertEquals(DRINK_WATER_EXPECTED_CONTEXT, ecm.encode());
+    }
+
+    @Test
+    public void testDecodeNullContext() throws JsonProcessingException {
+        Assertions.assertNull(ExecutionContextMetadata.decode(null));
+    }
+
+    @Test
+    public void testDecodeContextWithOnlyNextStepName() throws JsonProcessingException {
+        ExecutionContextMetadata ecm = ExecutionContextMetadata.decode(DELAY_EXIT_CONTEXT);
+        Assertions.assertNotNull(ecm);
+        Assertions.assertEquals(ExecutionContextMetadata.CURRENT_METADATA_VERSION, ecm.getMetadataVersion());
+        Assertions.assertEquals(DecisionTaskPoller.DELAY_EXIT_TIMER_ID, ecm.getNextStepName());
+        Assertions.assertNull(ecm.getResultCodeMap());
+    }
+
+    @Test
+    public void testDecodeContextWithResultCodeMap() throws JsonProcessingException {
+        ExecutionContextMetadata ecm = ExecutionContextMetadata.decode(EAT_SANDWICH_EXPECTED_CONTEXT);
+        Assertions.assertNotNull(ecm);
+        Assertions.assertEquals(ExecutionContextMetadata.CURRENT_METADATA_VERSION, ecm.getMetadataVersion());
+        Assertions.assertEquals(EatSandwich.class.getSimpleName(), ecm.getNextStepName());
+        Assertions.assertNotNull(ecm.getResultCodeMap());
+        Assertions.assertEquals(2, ecm.getResultCodeMap().size());
+        Assertions.assertEquals(DrinkWater.class.getSimpleName(),
+                                ecm.getResultCodeMap().get(StepResult.SUCCEED_RESULT_CODE));
+        Assertions.assertEquals(ThrowAwayBadSandwich.class.getSimpleName(),
+                                ecm.getResultCodeMap().get(StepResult.FAIL_RESULT_CODE));
+    }
+
+    @Test
+    public void testDecodeContextWithResultCodeMapWhenWorkflowEnds() throws JsonProcessingException {
+        ExecutionContextMetadata ecm = ExecutionContextMetadata.decode(DRINK_WATER_EXPECTED_CONTEXT);
+        Assertions.assertNotNull(ecm);
+        Assertions.assertEquals(ExecutionContextMetadata.CURRENT_METADATA_VERSION, ecm.getMetadataVersion());
+        Assertions.assertEquals(DrinkWater.class.getSimpleName(), ecm.getNextStepName());
+        Assertions.assertNotNull(ecm.getResultCodeMap());
+        Assertions.assertEquals(1, ecm.getResultCodeMap().size());
+        Assertions.assertEquals(ExecutionContextMetadata.NEXT_STEP_RESULT_WORKFLOW_ENDS,
+                                ecm.getResultCodeMap().get(StepResult.ALWAYS_RESULT_CODE));
+    }
+}


### PR DESCRIPTION
The execution context no longer encodes json values inside strings, and now includes an explicit version number.
Updated SIGNALS.md to reflect the new format.
Updated MIGRATION_TO_2.1 to describe how to handle the format change.

fixes https://github.com/danielgmyers/flux-swf-client/issues/105