### PR TITLE
Clean up versioning logic. No need to publish the parent pom anymore.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,6 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1.0.3
+        uses: aws-actions/aws-codebuild-run-build@v1.0.8
         with:
           project-name: ${{ env.CODEBUILD_PROJECT_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 */target/
 /target
+*.flattened-pom.xml

--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -5,12 +5,14 @@
     <parent>
         <groupId>com.danielgmyers.flux</groupId>
         <artifactId>flux-base-pom</artifactId>
-        <version>2.1.0</version>
+        <relativePath>../pom.xml</relativePath>
+        <version>0</version>
     </parent>
     <groupId>com.danielgmyers.flux</groupId>
     <artifactId>flux-common</artifactId>
-    <name>Flux SWF Client Common</name>
-    <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
+    <version>${flux.base.version}</version>
+    <name>Flux Workflow Client Common</name>
+    <description>Flux is a workflow client library to simplify writing asynchronous workflows.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
@@ -19,6 +21,10 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <skip.deploy>false</skip.deploy>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/flux-swf-guice/pom.xml
+++ b/flux-swf-guice/pom.xml
@@ -5,12 +5,14 @@
     <parent>
         <groupId>com.danielgmyers.flux</groupId>
         <artifactId>flux-base-pom</artifactId>
-        <version>2.1.0</version>
+        <relativePath>../pom.xml</relativePath>
+        <version>0</version>
     </parent>
     <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf-guice</artifactId>
+    <version>${flux.swf.version}</version>
     <name>Flux SWF Client Guice Helper</name>
-    <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
+    <description>Flux SWF Client Guice Helper makes Flux initialization easier when using Guice.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
@@ -19,6 +21,10 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <skip.deploy>false</skip.deploy>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -36,7 +42,7 @@
         <dependency>
             <artifactId>flux-swf</artifactId>
             <groupId>com.danielgmyers.flux.clients.swf</groupId>
-            <version>${flux.version}</version>
+            <version>${flux.swf.version}</version>
             <optional>false</optional>
         </dependency>
 

--- a/flux-swf-integration-tests/pom.xml
+++ b/flux-swf-integration-tests/pom.xml
@@ -5,12 +5,14 @@
     <parent>
         <groupId>com.danielgmyers.flux</groupId>
         <artifactId>flux-base-pom</artifactId>
-        <version>2.1.0</version>
+        <relativePath>../pom.xml</relativePath>
+        <version>0</version>
     </parent>
     <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf-integration-tests</artifactId>
+    <version>${flux.swf.version}</version>
     <name>Flux SWF Client integration tests</name>
-    <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
+    <description>Integration tests for validating Flux SWF Client functionality.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
@@ -25,7 +27,7 @@
         <dependency>
             <artifactId>flux-swf</artifactId>
             <groupId>com.danielgmyers.flux.clients.swf</groupId>
-            <version>${flux.version}</version>
+            <version>${flux.swf.version}</version>
             <optional>false</optional>
         </dependency>
 
@@ -66,46 +68,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <!-- disable sources.jar generation for the integ tests -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <configuration>
-                            <skipSource>true</skipSource>
-                        </configuration>
-                    </plugin>
-                    <!-- disable javadoc.jar generation for the integ tests -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <!-- disable gpg signing for the integ tests -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <!-- disable staging/publishing for the integ tests -->
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/flux-swf-spring/pom.xml
+++ b/flux-swf-spring/pom.xml
@@ -5,12 +5,14 @@
     <parent>
         <groupId>com.danielgmyers.flux</groupId>
         <artifactId>flux-base-pom</artifactId>
-        <version>2.1.0</version>
+        <relativePath>../pom.xml</relativePath>
+        <version>0</version>
     </parent>
     <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf-spring</artifactId>
+    <version>${flux.swf.version}</version>
     <name>Flux SWF Client Spring Helper</name>
-    <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
+    <description>Flux SWF Client Spring Helper makes Flux initialization easier when using Spring.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
@@ -19,6 +21,10 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <skip.deploy>false</skip.deploy>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -31,7 +37,7 @@
         <dependency>
             <artifactId>flux-swf</artifactId>
             <groupId>com.danielgmyers.flux.clients.swf</groupId>
-            <version>${flux.version}</version>
+            <version>${flux.swf.version}</version>
             <optional>false</optional>
         </dependency>
 

--- a/flux-swf/pom.xml
+++ b/flux-swf/pom.xml
@@ -5,12 +5,14 @@
     <parent>
         <groupId>com.danielgmyers.flux</groupId>
         <artifactId>flux-base-pom</artifactId>
-        <version>2.1.0</version>
+        <relativePath>../pom.xml</relativePath>
+        <version>0</version>
     </parent>
     <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf</artifactId>
+    <version>${flux.swf.version}</version>
     <name>Flux SWF Client</name>
-    <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
+    <description>Flux SWF Client implements the Flux Workflow Client interfaces on top of Amazon Simple Workflow Service.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
@@ -19,6 +21,10 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <skip.deploy>false</skip.deploy>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -61,7 +67,7 @@
         <dependency>
             <artifactId>flux-common</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.version}</version>
+            <version>${flux.base.version}</version>
             <optional>false</optional>
         </dependency>
 
@@ -93,7 +99,7 @@
         <dependency>
             <artifactId>flux-testutils</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.version}</version>
+            <version>${flux.base.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -5,12 +5,14 @@
     <parent>
         <groupId>com.danielgmyers.flux</groupId>
         <artifactId>flux-base-pom</artifactId>
-        <version>2.1.0</version>
+        <relativePath>../pom.xml</relativePath>
+        <version>0</version>
     </parent>
     <groupId>com.danielgmyers.flux</groupId>
     <artifactId>flux-testutils</artifactId>
-    <name>Flux SWF Client Test Utils</name>
-    <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
+    <version>${flux.base.version}</version>
+    <name>Flux Workflow Client Test Utils</name>
+    <description>Flux Workflow Client Test Utils provides helper code for writing tests against the Flux interfaces.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
         <license>
@@ -20,12 +22,16 @@
         </license>
     </licenses>
 
+    <properties>
+        <skip.deploy>false</skip.deploy>
+    </properties>
+
     <dependencies>
         <!-- flux internal dependencies -->
         <dependency>
             <artifactId>flux-common</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.version}</version>
+            <version>${flux.base.version}</version>
             <optional>false</optional>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.danielgmyers.flux</groupId>
     <artifactId>flux-base-pom</artifactId>
-    <version>2.1.0</version>
+    <version>0</version>
     <packaging>pom</packaging>
-    <name>Flux Base POM</name>
+    <name>Flux Workflow Client Base POM</name>
     <description>Flux is a workflow client library to simplify writing asynchronous workflows.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
     <licenses>
@@ -45,7 +45,10 @@
         <url>https://github.com/danielgmyers/flux-swf-client</url>
     </scm>
     <properties>
-        <flux.version>${project.version}</flux.version>
+        <!-- Flux's components get their own versions so that we can release them separately as needed. -->
+        <flux.base.version>2.1.0</flux.base.version>
+        <flux.swf.version>2.1.0</flux.swf.version>
+
         <awssdk.version>2.17.293</awssdk.version>
         <commons-codec.version>1.15</commons-codec.version>
         <jackson.version>2.14.0-rc2</jackson.version>
@@ -55,6 +58,7 @@
         <junit5.version>5.9.1</junit5.version>
         <easymock.version>5.0.0</easymock.version>
 
+        <mavenplugin.flatten.version>1.6.0</mavenplugin.flatten.version>
         <mavenplugin.compiler.version>3.10.1</mavenplugin.compiler.version>
         <mavenplugin.checkstyle.version>3.2.0</mavenplugin.checkstyle.version>
         <mavenplugin.surefire.version>2.22.2</mavenplugin.surefire.version>
@@ -66,9 +70,37 @@
         <checkstyle.version>10.3.4</checkstyle.version>
 
         <jre.version>11</jre.version>
+
+        <!-- Modules (including this parent pom) won't get deployed by default,
+             they'll need to override this to get deployed. -->
+        <skip.deploy>true</skip.deploy>
     </properties>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${mavenplugin.flatten.version}</version>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <flattenMode>oss</flattenMode>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -164,6 +196,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <skipSource>${skip.deploy}</skipSource>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -177,6 +212,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <skip>${skip.deploy}</skip>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -191,6 +229,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <skip>${skip.deploy}</skip>
                             <keyname>${env.GPG_KEY_ID}</keyname>
                             <passphrase>${env.GPG_PASSPHRASE}</passphrase>
                             <gpgArguments>
@@ -209,6 +248,7 @@
                             <serverId>sonatype-nexus-staging</serverId>
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>${publishing.autoReleaseAfterClose}</autoReleaseAfterClose>
+                            <skipNexusStagingDeployMojo>${skip.deploy}</skipNexusStagingDeployMojo>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Rework how the parent pom gets inherited; we don't need to version or publish it anymore, since the module poms get flattened during the build now.

Invert the logic for which modules get skipped during deploys, and make it so each module only needs to override a single property in order to enable deploys.

Version flux-common and flux-testutils separately from flux-swf so they can be released independently as needed.