### PR TITLE
Move workflowDomain parameter of FluxCapacitor.getRemoteWorkflowExecutor().

### DIFF
--- a/flux-common/src/main/java/com/danielgmyers/flux/FluxCapacitor.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/FluxCapacitor.java
@@ -69,9 +69,8 @@ public interface FluxCapacitor {
      *
      * @param endpointId This should be an identifier that can be used by the aforementioned configuration callbacks to determine
      *                   which configuration data to supply to the underlying client.
-     * @param workflowDomain The domain that the remote workflows should be executed in.
      */
-    RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId, String workflowDomain);
+    RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId);
 
     /**
      * Shuts down this FluxCapacitor object's worker thread pools. Running threads are not interrupted.

--- a/flux-swf-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/TestConfig.java
+++ b/flux-swf-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/TestConfig.java
@@ -23,10 +23,11 @@ public final class TestConfig {
     /**
      * Retrieves the configured remote region.
      */
-    public static RemoteSwfClientConfig getRemoteClientConfig() {
+    public static RemoteSwfClientConfig getRemoteClientConfig(String remoteWorkflowDomain) {
         RemoteSwfClientConfig config = new RemoteSwfClientConfig();
         config.setAwsRegion(System.getProperty("remoteRegion", "us-east-1"));
         config.setSwfEndpoint(System.getProperty("remoteEndpoint", null));
+        config.setWorkflowDomain(System.getProperty("remoteWorkflowDomain", remoteWorkflowDomain));
         return config;
     }
 
@@ -49,7 +50,7 @@ public final class TestConfig {
      * @param workerPoolSize - the size of the thread pool for the deciders and workers.
      */
     public static FluxCapacitorConfig generateRemoteFluxConfig(String swfDomain, int workerPoolSize) {
-        RemoteSwfClientConfig remoteConfig = getRemoteClientConfig();
+        RemoteSwfClientConfig remoteConfig = getRemoteClientConfig(swfDomain);
         return generateFluxConfig(remoteConfig.getAwsRegion(), swfDomain, workerPoolSize);
     }
 

--- a/flux-swf-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/WorkflowTestBase.java
+++ b/flux-swf-integration-tests/src/test/java/com/danielgmyers/flux/clients/swf/tests/WorkflowTestBase.java
@@ -50,7 +50,7 @@ public abstract class WorkflowTestBase {
     }
 
     protected RemoteWorkflowExecutor getRemoteWorkflowExecutor() {
-        return capacitor.getRemoteWorkflowExecutor("test", getWorkflowDomain());
+        return capacitor.getRemoteWorkflowExecutor("test");
     }
 
     abstract List<Workflow> getWorkflowsForTest();
@@ -81,7 +81,7 @@ public abstract class WorkflowTestBase {
         if (localRegion) {
             swfClientBuilder.region(Region.of(TestConfig.getAwsRegion()));
         } else {
-            swfClientBuilder.region(Region.of(TestConfig.getRemoteClientConfig().getAwsRegion()));
+            swfClientBuilder.region(Region.of(TestConfig.getRemoteClientConfig(getWorkflowDomain()).getAwsRegion()));
         }
         return swfClientBuilder.build();
     }
@@ -94,7 +94,7 @@ public abstract class WorkflowTestBase {
         }  else {
             config = TestConfig.generateRemoteFluxConfig(getWorkflowDomain(), getWorkerPoolThreadCount());
         }
-        config.setRemoteSwfClientConfigProvider((s) -> TestConfig.getRemoteClientConfig());
+        config.setRemoteSwfClientConfigProvider((s) -> TestConfig.getRemoteClientConfig(getWorkflowDomain()));
         updateFluxCapacitorConfig(config);
         FluxCapacitor capacitor = FluxCapacitorFactory.create(new NoopMetricRecorderFactory(),
                                                               DefaultCredentialsProvider.create(), config);

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorImpl.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/FluxCapacitorImpl.java
@@ -252,9 +252,9 @@ public final class FluxCapacitorImpl implements FluxCapacitor {
     }
 
     @Override
-    public RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId, String workflowDomain) {
-        // for the regular FluxCapacitor SwfClient, we disabled all the retry logic
-        // since we do our own for metrics purposes. However the remote client is not used
+    public RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId) {
+        // For the regular FluxCapacitor SwfClient, we disabled all the retry logic
+        // since we do our own for metrics purposes. However, the remote client is not used
         // for much, and we don't bother emitting metrics for it, so the defaults are fine.
 
         Function<String, RemoteSwfClientConfig> remoteConfigProvider = config.getRemoteSwfClientConfigProvider();
@@ -279,7 +279,7 @@ public final class FluxCapacitorImpl implements FluxCapacitor {
         if (remoteConfig.getSwfEndpoint() != null) {
             customSwf.endpointOverride(URI.create(remoteConfig.getSwfEndpoint()));
         }
-        return new RemoteWorkflowExecutorImpl(clock, metricsFactory, workflowsByName, customSwf.build(), config);
+        return new RemoteWorkflowExecutorImpl(clock, metricsFactory, workflowsByName, customSwf.build(), remoteConfig);
     }
 
     @Override

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/RemoteSwfClientConfig.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/RemoteSwfClientConfig.java
@@ -21,15 +21,17 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 
 /**
  * Allows users to provide SWF client configuration to be used to create a RemoteWorkflowExecutor.
- * Note that at a minimum, the AWS region must not be null.
+ * Note that at a minimum, the AWS region and workflow domain must not be null.
  * If credentials is null, DefaultCredentialsProvider will be used.
  * If swfEndpoint and clientOverrideConfiguration are null they will be ignored.
  */
 public class RemoteSwfClientConfig {
     private String awsRegion;
     private String swfEndpoint;
+    private String workflowDomain;
     private AwsCredentialsProvider credentials;
     private ClientOverrideConfiguration clientOverrideConfiguration;
+    private Boolean automaticallyTagExecutionsWithTaskList;
 
     public String getAwsRegion() {
         return awsRegion;
@@ -47,6 +49,14 @@ public class RemoteSwfClientConfig {
         this.swfEndpoint = swfEndpoint;
     }
 
+    public String getWorkflowDomain() {
+        return workflowDomain;
+    }
+
+    public void setWorkflowDomain(String workflowDomain) {
+        this.workflowDomain = workflowDomain;
+    }
+
     public AwsCredentialsProvider getCredentials() {
         return credentials;
     }
@@ -61,5 +71,13 @@ public class RemoteSwfClientConfig {
 
     public void setClientOverrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration) {
         this.clientOverrideConfiguration = clientOverrideConfiguration;
+    }
+
+    public Boolean getAutomaticallyTagExecutionsWithTaskList() {
+        return automaticallyTagExecutionsWithTaskList;
+    }
+
+    public void setAutomaticallyTagExecutionsWithTaskList(Boolean automaticallyTagExecutionsWithTaskList) {
+        this.automaticallyTagExecutionsWithTaskList = automaticallyTagExecutionsWithTaskList;
     }
 }

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutorImpl.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutorImpl.java
@@ -46,10 +46,10 @@ public class RemoteWorkflowExecutorImpl implements RemoteWorkflowExecutor {
     private final MetricRecorderFactory metricsFactory;
     private final Map<String, Workflow> workflowsByName;
     private final SwfClient swf;
-    private final FluxCapacitorConfig config;
+    private final RemoteSwfClientConfig config;
 
     RemoteWorkflowExecutorImpl(Clock clock, MetricRecorderFactory metricsFactory, Map<String, Workflow> workflowsByName,
-                               SwfClient swf, FluxCapacitorConfig config) {
+                               SwfClient swf, RemoteSwfClientConfig config) {
         this.clock = clock;
         this.metricsFactory = metricsFactory;
         this.swf = swf;
@@ -81,7 +81,7 @@ public class RemoteWorkflowExecutorImpl implements RemoteWorkflowExecutor {
         }
 
         StartWorkflowExecutionRequest request
-                = FluxCapacitorImpl.buildStartWorkflowRequest(config.getSwfDomain(), workflowName, workflowId,
+                = FluxCapacitorImpl.buildStartWorkflowRequest(config.getWorkflowDomain(), workflowName, workflowId,
                                                               workflow.taskList(), workflow.maxStartToCloseDuration(),
                                                               workflowInput, actualExecutionTags);
 
@@ -92,7 +92,7 @@ public class RemoteWorkflowExecutorImpl implements RemoteWorkflowExecutor {
             log.debug("Started remote workflow {} with id {}: received execution id {}.",
                       workflowName, workflowId, workflowRun.runId());
 
-            return new WorkflowStatusCheckerImpl(clock, swf, config.getSwfDomain(), workflowId, workflowRun.runId());
+            return new WorkflowStatusCheckerImpl(clock, swf, config.getWorkflowDomain(), workflowId, workflowRun.runId());
         } catch (WorkflowExecutionAlreadyStartedException e) {
             // swallow, we're ok with this happening
             log.debug("Attempted to start remote workflow {} with id {} but it was already started.",

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutorTest.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/RemoteWorkflowExecutorTest.java
@@ -47,7 +47,7 @@ public class RemoteWorkflowExecutorTest {
     private RemoteWorkflowExecutorImpl rwe;
 
     private Workflow workflow;
-    private FluxCapacitorConfig config;
+    private RemoteSwfClientConfig config;
 
     @BeforeEach
     public void setup() {
@@ -61,8 +61,8 @@ public class RemoteWorkflowExecutorTest {
         Map<String, Workflow> workflowsByName = new HashMap<>();
         workflowsByName.put(TaskNaming.workflowName(workflow), workflow);
 
-        config = new FluxCapacitorConfig();
-        config.setSwfDomain("test");
+        config = new RemoteSwfClientConfig();
+        config.setWorkflowDomain("test");
 
         rwe = new RemoteWorkflowExecutorImpl(clock, new NoopMetricRecorderFactory(), workflowsByName, swf, config);
     }
@@ -154,7 +154,7 @@ public class RemoteWorkflowExecutorTest {
     private void expectStartWorkflowRequest(Workflow workflow, String workflowId, Map<String, Object> input,
                                             Set<String> executionTags, Exception exceptionToThrow) {
         StartWorkflowExecutionRequest start
-                = FluxCapacitorImpl.buildStartWorkflowRequest(config.getSwfDomain(), TaskNaming.workflowName(workflow),
+                = FluxCapacitorImpl.buildStartWorkflowRequest(config.getWorkflowDomain(), TaskNaming.workflowName(workflow),
                                                               workflowId, workflow.taskList(),
                                                               workflow.maxStartToCloseDuration(), input, executionTags);
         if (exceptionToThrow == null) {

--- a/flux-testutils/src/main/java/com/danielgmyers/flux/testutil/StubFluxCapacitor.java
+++ b/flux-testutils/src/main/java/com/danielgmyers/flux/testutil/StubFluxCapacitor.java
@@ -99,7 +99,7 @@ public class StubFluxCapacitor implements FluxCapacitor {
     }
 
     @Override
-    public RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId, String workflowDomain) {
+    public RemoteWorkflowExecutor getRemoteWorkflowExecutor(String endpointId) {
         return new StubRemoteWorkflowExecutor();
     }
 


### PR DESCRIPTION
This is now a field on RemoteSwfClientConfig, along with AutomaticallyTagExecutionsWithTaskList, and flux-swf's RemoteWorkflowExecutorImpl no longer references the main FluxCapacitorConfig at all.

I don't need to update the migration-to-2.1 doc here since the doc already implies that all of the SWF-specific config was moved behind RemoteSwfClientConfig... this PR makes that true!

https://github.com/danielgmyers/flux-swf-client/issues/128
