### PR TITLE
[flux-swf] Extract common ActivityExecutor logic into flux-common. Add generic StepInputAccessor interface.

### DIFF
--- a/MIGRATION_TO_2.1.md
+++ b/MIGRATION_TO_2.1.md
@@ -75,6 +75,19 @@ Flux will attempt to properly handle any partitioned workflow steps that are run
 
 The `EnablePartitionIdHashing` feature is disabled by default in 2.1.0.
 
+Workflow Step attribute changes
+----
+
+Prior to 2.1.0, if a `@StepApply` method requested a `Map<String, String>` attribute as one of its inputs, and that attribute was not present in the workflow metadata, Flux would provide an empty, mutable `HashMap<String, String>`. However, to help users understand the difference between "previous step did not provide the map" and "previous step provided an empty map", Flux no longer automatically provides an empty map in this case.
+
+Also prior to 2.1.0, Flux would automatically convert attribute values between `Instant` and `Date` depending on which was requested by the step, regardless of which of the two types was actually used as the attribute type when the attribute was added earlier in the workflow. While this will still work *in practice* for 2.1.0, Flux ***no longer guarantees*** this behavior.
+
+This also means that the WorkflowGraphBuilder's built-in attribute availability check no longer ignores the type difference between `Instant` and `Date` when evaluating attribute availability, including for the built-in `StepAttribute.ACTIVITY_INITIAL_ATTEMPT_TIME` and `StepAttribute.WORKFLOW_START_TIME` attributes (which are provided as `Instant`s). As a result, your `WorkflowGraphBuilder.build()` calls may being failing if you are presently relying on this behavior.
+
+You should update your workflow input and output attributes to use `Instant` instead of `Date` in all cases.
+
+Flux will drop support for the `Date` type in a future release.
+
 Execution context changes
 ----
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ This step is set up the same as `Hello`, except that its `@StepApply` method has
 Flux supports `@Attribute` parameters of any of the following types:
 - `String`
 - `Long`
-- `Date`
 - `Instant`
 - `Boolean`
 - `Map<String, String>`
 - `com.danielgmyers.flux.clients.swf.metrics.MetricRecorder`
+
+Support for the `Date` type is still present but is deprecated, and will be removed in a future release. 
 
 If more complex types are needed, it is recommended that you serialize the value into a `String` or a `Map<String, String>`.
 

--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -66,9 +66,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>slf4j-nop</artifactId>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.danielgmyers.metrics</groupId>
+            <artifactId>in-memory-recorder</artifactId>
+            <version>${metricrecorder.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/flux-common/src/main/java/com/danielgmyers/flux/ex/AttributeTypeMismatchException.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/ex/AttributeTypeMismatchException.java
@@ -1,0 +1,28 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.ex;
+
+/**
+ * Indicates that an attribute was requested with one type, but the actual attribute found in the workflow
+ * metadata was of a different (presumably incompatible) type.
+ */
+public class AttributeTypeMismatchException extends FluxException {
+    public AttributeTypeMismatchException(Class<?> requestedType, String attributeName, Class<?> actualType) {
+        super(String.format("Requested type %s for attribute %s, but found type %s.",
+                            requestedType.getSimpleName(), attributeName, actualType.getSimpleName()));
+    }
+}

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/StepAttributes.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/StepAttributes.java
@@ -98,11 +98,7 @@ public final class StepAttributes {
         try {
             validateAttributeClass(type);
 
-            if (encoded == null || encoded.equals("")) {
-                // for convenience, if the requested type was a map, return a matching empty collection.
-                if (Map.class == type) {
-                    return (T)(new HashMap<>());
-                }
+            if (encoded == null || encoded.isEmpty()) {
                 return null;
             } else {
                 if (type == Instant.class) {

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/StepInputAccessor.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/StepInputAccessor.java
@@ -1,0 +1,31 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.step;
+
+/**
+ * Provides an implementation-independent mechanism for retrieving step inputs from common code.
+ */
+public interface StepInputAccessor {
+    /**
+     * Returns the requested attribute as an object of the requested type.
+     * Implementations _may_ convert the actual attribute value to the requested type if doing so makes sense;
+     * otherwise, implementations should throw AttributeTypeMismatchException when the type is incorrect.
+     *
+     * If the attribute does not exist, this method should return null.
+     */
+    <T> T getAttribute(Class<T> requestedType, String attributeName);
+}

--- a/flux-common/src/main/java/com/danielgmyers/flux/wf/graph/WorkflowGraphBuilder.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/wf/graph/WorkflowGraphBuilder.java
@@ -18,10 +18,8 @@ package com.danielgmyers.flux.wf.graph;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -42,7 +40,7 @@ import com.danielgmyers.flux.step.StepHook;
 import com.danielgmyers.flux.step.StepResult;
 import com.danielgmyers.flux.step.WorkflowStep;
 import com.danielgmyers.flux.step.WorkflowStepHook;
-import com.danielgmyers.flux.step.WorkflowStepUtil;
+import com.danielgmyers.flux.step.internal.WorkflowStepUtil;
 import com.danielgmyers.metrics.MetricRecorder;
 
 /**
@@ -550,7 +548,7 @@ public class WorkflowGraphBuilder {
             verifyNoLoops(node.getStep().getClass(), nodes, visited);
         }
 
-        // if we get here, there we no loops including this node
+        // if we get here, there were no loops including this node
         visited.remove(step);
     }
 
@@ -577,13 +575,6 @@ public class WorkflowGraphBuilder {
                 }
 
                 Class<?> paramType = param.getType();
-                if (paramType == Date.class) {
-                    // The step attribute encoding/decoding logic allows Date and Instant to be used
-                    // interchangeably, so for the purposes of attribute availability,
-                    // we'll coerce all Dates to Instants, to simplify the validation logic.
-                    paramType = Instant.class;
-                }
-
                 validateAttributeIdAndType(step.getClass().getSimpleName(), partitionIdGenerator.getName(), attr.value(),
                                            paramType, attr.optional(), availableAttributes);
             }
@@ -608,13 +599,6 @@ public class WorkflowGraphBuilder {
             Class<?> paramType = param.getType();
             if (paramType.isAssignableFrom(MetricRecorder.class)) {
                 continue;
-            }
-
-            if (paramType == Date.class) {
-                // The step attribute encoding/decoding logic allows Date and Instant to be used
-                // interchangeably, so for the purposes of attribute availability,
-                // we'll coerce all Dates to Instants, to simplify the validation logic.
-                paramType = Instant.class;
             }
 
             Attribute attr = param.getAnnotation(Attribute.class);
@@ -688,13 +672,6 @@ public class WorkflowGraphBuilder {
                 Class<?> paramType = param.getType();
                 if (paramType.isAssignableFrom(MetricRecorder.class)) {
                     continue;
-                }
-
-                if (paramType == Date.class) {
-                    // The step attribute encoding/decoding logic allows Date and Instant to be used
-                    // interchangeably, so for the purposes of attribute availability,
-                    // we'll coerce all Dates to Instants, to simplify the validation logic.
-                    paramType = Instant.class;
                 }
 
                 Attribute attr = param.getAnnotation(Attribute.class);

--- a/flux-common/src/test/java/com/danielgmyers/flux/step/StepAttributesTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/step/StepAttributesTest.java
@@ -42,7 +42,7 @@ public class StepAttributesTest {
         for (Class<?> t : StepAttributes.ALLOWED_TYPES) {
             Assertions.assertNull(StepAttributes.decode(t, null));
         }
-        Assertions.assertEquals(Collections.emptyMap(), StepAttributes.decode(Map.class, null));
+        Assertions.assertNull(StepAttributes.decode(Map.class, null));
     }
 
     @Test
@@ -55,7 +55,7 @@ public class StepAttributesTest {
                 Assertions.assertNull(StepAttributes.decode(t, ""));
             }
         }
-        Assertions.assertEquals(Collections.emptyMap(), StepAttributes.decode(Map.class, ""));
+        Assertions.assertNull(StepAttributes.decode(Map.class, ""));
     }
 
     @Test

--- a/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
@@ -1,0 +1,749 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.step.internal;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.Attribute;
+import com.danielgmyers.flux.step.StepApply;
+import com.danielgmyers.flux.step.StepAttributes;
+import com.danielgmyers.flux.step.StepHook;
+import com.danielgmyers.flux.step.StepInputAccessor;
+import com.danielgmyers.flux.step.StepResult;
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.step.WorkflowStepHook;
+import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.flux.wf.graph.PostWorkflowHookAnchor;
+import com.danielgmyers.flux.wf.graph.PreWorkflowHookAnchor;
+import com.danielgmyers.flux.wf.graph.WorkflowGraph;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphBuilder;
+import com.danielgmyers.metrics.MetricRecorder;
+import com.danielgmyers.metrics.recorders.InMemoryMetricRecorder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ActivityExecutionUtilTest {
+
+    private DummyStep step;
+    private StepWithSeveralInputs stepWithSeveralInputs;
+    private InMemoryMetricRecorder fluxMetrics;
+    private InMemoryMetricRecorder stepMetrics;
+
+    private StepInputAccessor emptyInput;
+
+    @BeforeEach
+    public void setup() {
+        step = new DummyStep();
+        stepWithSeveralInputs = new StepWithSeveralInputs();
+
+        fluxMetrics = new InMemoryMetricRecorder("ActivityExecutionUtil");
+        stepMetrics = new InMemoryMetricRecorder(TaskNaming.activityName(TestWorkflow.class, DummyStep.class));
+
+        emptyInput = new StepInputAccessor() {
+            @Override
+            public <T> T getAttribute(Class<T> requestedType, String attributeName) {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void testExecuteActivity_returnsCompleteForSuccessCase() {
+        WorkflowGraphBuilder graph = new WorkflowGraphBuilder(step);
+        graph.alwaysClose(step);
+
+        Workflow workflow = new TestWorkflow(graph.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(result);
+
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+
+        String activityName = TaskNaming.activityName(workflow, step);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput);
+        Assertions.assertTrue(step.didThing());
+
+        // fluxMetrics needs to be closed by the caller to executeActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
+                result.getResultCode())).intValue());
+    }
+
+    @Test
+    public void testExecuteActivity_returnsRetryWhenApplyReturnsRetry() {
+        WorkflowGraphBuilder graph = new WorkflowGraphBuilder(step);
+        graph.alwaysClose(step);
+
+        Workflow workflow = new TestWorkflow(graph.build());
+
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.RETRY, null, "hmm", Collections.emptyMap());
+        step.setStepResult(expectedResult);
+
+        String activityName = TaskNaming.activityName(workflow, step);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput);
+        Assertions.assertTrue(step.didThing()); // true because the step did a thing before specifically deciding to return retry
+
+        // fluxMetrics needs to be closed by the caller to executeActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatRetryResultMetricName(TaskNaming.activityName(workflow, step),
+                null)).intValue());
+    }
+
+    @Test
+    public void testExecuteActivity_returnsRetryWhenApplyThrowsException() {
+        WorkflowGraphBuilder graph = new WorkflowGraphBuilder(step);
+        graph.alwaysClose(step);
+
+        Workflow workflow = new TestWorkflow(graph.build());
+
+        RuntimeException e = new RuntimeException("message!");
+        step.setExceptionToThrow(e);
+
+        StepResult expectedResult = StepResult.retry(e);
+
+        String activityName = TaskNaming.activityName(workflow, step);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput);
+        Assertions.assertFalse(step.didThing()); // false because the step threw an exception in the middle of doing the thing
+
+        // fluxMetrics needs to be closed by the caller to executeActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatRetryResultMetricName(TaskNaming.activityName(workflow, step),
+                e.getClass().getSimpleName())).intValue());
+    }
+
+    @Test
+    public void testExecuteActivity_properlyMapsAttributesToParameters() {
+        WorkflowGraphBuilder graph = new WorkflowGraphBuilder(stepWithSeveralInputs);
+        graph.alwaysClose(stepWithSeveralInputs);
+
+        Workflow workflow = new TestWorkflow(graph.build());
+
+        String stringParam = "foo";
+        Long longParam = 42L;
+        Boolean booleanParam = true;
+        Map<String, String> stringMap = new HashMap<>();
+        stringMap.put("bar", "baz");
+        stringMap.put("zap", null);
+
+        stepWithSeveralInputs = new StepWithSeveralInputs();
+        stepWithSeveralInputs.setExpectedString(stringParam);
+        stepWithSeveralInputs.setExpectedLong(longParam);
+        stepWithSeveralInputs.setExpectedBoolean(booleanParam);
+        stepWithSeveralInputs.setExpectedStringMap(stringMap);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put(StepWithSeveralInputs.STRING_PARAM, stringParam);
+        input.put(StepWithSeveralInputs.LONG_PARAM, longParam);
+        input.put(StepWithSeveralInputs.BOOLEAN_PARAM, booleanParam);
+        input.put(StepWithSeveralInputs.STRING_MAP_PARAM, stringMap);
+
+        StepInputAccessor inputAccessor = new StepInputAccessor() {
+            @Override
+            public <T> T getAttribute(Class<T> requestedType, String attributeName) {
+                return (T)(input.get(attributeName));
+            }
+        };
+
+        String activityName = TaskNaming.activityName(workflow, stepWithSeveralInputs);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(stepWithSeveralInputs, activityName, fluxMetrics, stepMetrics, inputAccessor);
+
+        // The stub step has a return type of void, so it should always just be a plain success result.
+        Assertions.assertEquals(StepResult.success(), actualResult);
+
+        // fluxMetrics needs to be closed by the caller to executeActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(activityName,
+                StepResult.SUCCEED_RESULT_CODE)).intValue());
+    }
+
+    public static class StepWithMetrics implements WorkflowStep {
+
+        private final String metricName;
+
+        public StepWithMetrics(String metricName) {
+            this.metricName = metricName;
+        }
+        @StepApply
+        public void doThing(MetricRecorder metrics) {
+            metrics.addCount(metricName, 1.0);
+        }
+    }
+
+    @Test
+    public void testExecuteActivity_passesInStepMetrics() {
+        final String stepMetric = "foo";
+
+        WorkflowStep stepWithMetrics = new StepWithMetrics(stepMetric);
+        WorkflowGraphBuilder graph = new WorkflowGraphBuilder(stepWithMetrics);
+        graph.alwaysClose(stepWithMetrics);
+
+        Workflow workflow = new TestWorkflow(graph.build());
+
+        String activityName = TaskNaming.activityName(workflow, stepWithMetrics);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(stepWithMetrics, activityName, fluxMetrics, stepMetrics, emptyInput);
+
+        // The stub step has a return type of void, so it should always just be a plain success result.
+        Assertions.assertEquals(StepResult.success(), actualResult);
+
+        // the metrics objects need to be closed by the caller to executeActivity.
+        // We need to close them so we can query their data.
+        fluxMetrics.close();
+        stepMetrics.close();
+
+        Assertions.assertTrue(stepMetrics.getCounts().containsKey(stepMetric));
+        Assertions.assertEquals(1, stepMetrics.getCounts().get(stepMetric).longValue());
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(activityName,
+                StepResult.SUCCEED_RESULT_CODE)).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_runsPreAndPostHooksForStep() {
+        TestPreStepHook hook = new TestPreStepHook();
+        TestPostStepHook hook2 = new TestPostStepHook();
+        TestPreAndPostStepHook hook3 = new TestPreAndPostStepHook();
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, hook);
+        builder.addStepHook(step, hook2);
+        builder.addStepHook(step, hook3);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(result);
+
+        Map<String, Object> fullOutput = new HashMap<>(output);
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", fullOutput);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, hook.getPreStepHookCallCount());
+        Assertions.assertEquals(1, hook2.getPostStepHookCallCount());
+        Assertions.assertEquals(1, hook3.getPreStepHookCallCount());
+        Assertions.assertEquals(1, hook3.getPostStepHookCallCount());
+
+        // fluxMetrics needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreStepHook.class.getSimpleName(),
+                "preStepHook", TaskNaming.activityName(workflow, step))));
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostStepHook.class.getSimpleName(),
+                "postStepHook", TaskNaming.activityName(workflow, step))));
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
+                "preStepHook", TaskNaming.activityName(workflow, step))));
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
+                "postStepHook", TaskNaming.activityName(workflow, step))));
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
+                result.getResultCode())).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_runsPreAndPostHooksForStep_PassInHookMetrics() {
+        WorkflowStepHook metricsHook = new TestHookWithMetrics();
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, metricsHook);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(expectedResult);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertTrue(step.didThing());
+
+        // both metrics objects needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close them so we can query their data.
+        fluxMetrics.close();
+        stepMetrics.close();
+
+        Assertions.assertTrue(stepMetrics.getCounts().containsKey(TestHookWithMetrics.PRE_HOOK_METRIC_NAME));
+        Assertions.assertTrue(stepMetrics.getCounts().containsKey(TestHookWithMetrics.POST_HOOK_METRIC_NAME));
+        Assertions.assertEquals(1, stepMetrics.getCounts().get(TestHookWithMetrics.PRE_HOOK_METRIC_NAME).longValue());
+        Assertions.assertEquals(1, stepMetrics.getCounts().get(TestHookWithMetrics.POST_HOOK_METRIC_NAME).longValue());
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestHookWithMetrics.class.getSimpleName(),
+                "preStepHook", TaskNaming.activityName(workflow, step))));
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestHookWithMetrics.class.getSimpleName(),
+                "postStepHook", TaskNaming.activityName(workflow, step))));
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
+                expectedResult.getResultCode())).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_runsOnlyPreHooksForPreWorkflowHookAnchor() {
+        TestPreStepHook hook = new TestPreStepHook();
+        TestPostStepHook hook2 = new TestPostStepHook();
+        TestPreAndPostStepHook hook3 = new TestPreAndPostStepHook();
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addWorkflowHook(hook);
+        builder.addWorkflowHook(hook2);
+        builder.addWorkflowHook(hook3);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = new HashMap<>();
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, null, output);
+
+        WorkflowStep anchorStep = workflow.getGraph().getFirstStep();
+        Assertions.assertEquals(PreWorkflowHookAnchor.class, anchorStep.getClass());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, anchorStep, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertEquals(1, hook.getPreStepHookCallCount());
+        Assertions.assertEquals(0, hook2.getPostStepHookCallCount());
+        Assertions.assertEquals(1, hook3.getPreStepHookCallCount());
+        Assertions.assertEquals(0, hook3.getPostStepHookCallCount());
+
+        // fluxMetrics needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreStepHook.class.getSimpleName(),
+                "preStepHook", TaskNaming.activityName(workflow, anchorStep))));
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
+                "preStepHook", TaskNaming.activityName(workflow, anchorStep))));
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, anchorStep),
+                StepResult.SUCCEED_RESULT_CODE)).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_runsOnlyPostHooksForPostWorkflowHookAnchor() {
+        TestPreStepHook hook = new TestPreStepHook();
+        TestPostStepHook hook2 = new TestPostStepHook();
+        TestPreAndPostStepHook hook3 = new TestPreAndPostStepHook();
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addWorkflowHook(hook);
+        builder.addWorkflowHook(hook2);
+        builder.addWorkflowHook(hook3);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = new HashMap<>();
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, null, output);
+
+        Assertions.assertNotNull(workflow.getGraph().getNodes().get(PostWorkflowHookAnchor.class));
+        WorkflowStep anchorStep = workflow.getGraph().getNodes().get(PostWorkflowHookAnchor.class).getStep();
+        Assertions.assertNotNull(anchorStep);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, anchorStep, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertEquals(0, hook.getPreStepHookCallCount());
+        Assertions.assertEquals(1, hook2.getPostStepHookCallCount());
+        Assertions.assertEquals(0, hook3.getPreStepHookCallCount());
+        Assertions.assertEquals(1, hook3.getPostStepHookCallCount());
+
+        // fluxMetrics needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostStepHook.class.getSimpleName(),
+                "postStepHook", TaskNaming.activityName(workflow, anchorStep))));
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
+                "postStepHook", TaskNaming.activityName(workflow, anchorStep))));
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, anchorStep),
+                StepResult.SUCCEED_RESULT_CODE)).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_ignoresFailureInPreHook_HookRetryOnFailureDisabled() {
+        RuntimeException e = new RuntimeException("Wheeee!");
+        WorkflowStepHook hook = new TestPreHookThrowsExceptionNoRetryOnFailure(e);
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, hook);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(expectedResult);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertTrue(step.didThing());
+
+        // fluxMetrics needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreHookThrowsExceptionNoRetryOnFailure.class.getSimpleName(),
+                "preStepHook", TaskNaming.activityName(workflow, step))));
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
+                expectedResult.getResultCode())).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_retryOnFailureInPreHook_HookRetryOnFailureEnabled() {
+        RuntimeException e = new RuntimeException("Wheeee!");
+        WorkflowStepHook hook = new TestPreHookThrowsExceptionRetryOnFailure(e);
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, hook);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertFalse(step.didThing()); // false because the pre-hook required a retry on failure, so the step never ran
+
+        // fluxMetrics needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(StepResult.ResultAction.RETRY, actualResult.getAction());
+        Assertions.assertNull(actualResult.getResultCode());
+        Assertions.assertNotNull(actualResult.getMessage());
+        Assertions.assertTrue(actualResult.getMessage().contains(TestPreHookThrowsExceptionRetryOnFailure.class.getSimpleName())
+                              && actualResult.getMessage().contains(e.getMessage()));
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreHookThrowsExceptionRetryOnFailure.class.getSimpleName(),
+                "preStepHook", TaskNaming.activityName(workflow, step))));
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_ignoresFailureInPostHook_HookRetryOnFailureDisabled() {
+        RuntimeException e = new RuntimeException("Wheeee!");
+        WorkflowStepHook hook = new TestPostHookThrowsExceptionNoRetryOnFailure(e);
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, hook);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(expectedResult);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertTrue(step.didThing());
+
+        // fluxMetrics needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostHookThrowsExceptionNoRetryOnFailure.class.getSimpleName(),
+                "postStepHook", TaskNaming.activityName(workflow, step))));
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
+                expectedResult.getResultCode())).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_retryOnFailureInPostHook_HookRetryOnFailureEnabled() {
+        RuntimeException e = new RuntimeException("Wheeee!");
+        WorkflowStepHook hook = new TestPostHookThrowsExceptionRetryOnFailure(e);
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, hook);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(result);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertTrue(step.didThing()); // true because the step runs before the hook
+
+        // fluxMetrics needs to be closed by the caller to executeHooksAndActivity.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Assertions.assertEquals(StepResult.ResultAction.RETRY, actualResult.getAction());
+        Assertions.assertNull(actualResult.getResultCode());
+        Assertions.assertNotNull(actualResult.getMessage());
+        Assertions.assertTrue(actualResult.getMessage().contains(TestPostHookThrowsExceptionRetryOnFailure.class.getSimpleName())
+                && actualResult.getMessage().contains(e.getMessage()));
+
+        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostHookThrowsExceptionRetryOnFailure.class.getSimpleName(),
+                "postStepHook", TaskNaming.activityName(workflow, step))));
+
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
+                result.getResultCode())).intValue());
+    }
+
+    private StepResult makeStepResult(StepResult.ResultAction resultAction, String stepResult, String message, Map<String, Object> output) {
+        return new StepResult(resultAction, stepResult, message).withAttributes(output);
+    }
+
+    public static class TestWorkflow implements Workflow {
+
+        private final WorkflowGraph graph;
+
+        public TestWorkflow(WorkflowGraph graph) {
+            this.graph = graph;
+        }
+
+        @Override
+        public WorkflowGraph getGraph() {
+            return graph;
+        }
+    }
+
+    public static class DummyStep implements WorkflowStep {
+
+        private boolean didThing = false;
+        private RuntimeException exceptionToThrow = null;
+        private StepResult result = null;
+        private long sleepDurationMillis = 0;
+
+        public void setExceptionToThrow(RuntimeException e) {
+            this.exceptionToThrow = e;
+        }
+
+        public void setStepResult(StepResult result) {
+            this.result = result;
+        }
+
+        public void setSleepDurationMillis(long sleepDurationMillis) {
+            this.sleepDurationMillis = sleepDurationMillis;
+        }
+
+        @StepApply
+        public StepResult doThing() throws InterruptedException {
+            if(exceptionToThrow != null) {
+                throw exceptionToThrow;
+            }
+
+            if(sleepDurationMillis > 0) {
+                Thread.sleep(sleepDurationMillis);
+            }
+
+            didThing = true;
+            return result;
+        }
+
+        public boolean didThing() {
+            return didThing;
+        }
+    }
+
+    public static class StepWithSeveralInputs implements WorkflowStep {
+
+        public static final String STRING_PARAM = "someStringValue";
+        public static final String LONG_PARAM = "someLongValue";
+        public static final String BOOLEAN_PARAM = "someBooleanValue";
+        public static final String STRING_MAP_PARAM = "someStringMap";
+
+        private String expectedString;
+        private Long expectedLong;
+        private Boolean expectedBoolean;
+        private Map<String, String> expectedStringMap;
+
+        @StepApply
+        public void apply(@Attribute(STRING_PARAM) String stringParam,
+                          @Attribute(LONG_PARAM) Long longParam,
+                          @Attribute(BOOLEAN_PARAM) Boolean booleanParam,
+                          @Attribute(STRING_MAP_PARAM) Map<String, String> stringMap,
+                          @Attribute("ThisShouldBeNull") String nullParam) {
+            Assertions.assertNotNull(stringParam);
+            Assertions.assertNotNull(longParam);
+            Assertions.assertNotNull(booleanParam);
+            Assertions.assertNotNull(stringMap);
+            Assertions.assertNull(nullParam);
+
+            Assertions.assertEquals(expectedString, stringParam);
+            Assertions.assertEquals(expectedLong, longParam);
+            Assertions.assertEquals(expectedBoolean, booleanParam);
+            Assertions.assertEquals(expectedStringMap, stringMap);
+        }
+
+        public void setExpectedString(String expectedString) {
+            this.expectedString = expectedString;
+        }
+
+        public void setExpectedLong(Long expectedLong) {
+            this.expectedLong = expectedLong;
+        }
+
+        public void setExpectedBoolean(Boolean expectedBoolean) {
+            this.expectedBoolean = expectedBoolean;
+        }
+
+        public void setExpectedStringMap(Map<String, String> expectedStringMap) {
+            this.expectedStringMap = expectedStringMap;
+        }
+    }
+
+    public static class TestPreStepHook implements WorkflowStepHook {
+
+        private int preStepHookCallCount = 0;
+
+        @StepHook(hookType = StepHook.HookType.PRE)
+        public void preStepHook(@Attribute(StepAttributes.ACTIVITY_NAME) String activityName,
+                                @Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Date activityStartTime,
+                                @Attribute(StepAttributes.WORKFLOW_ID) String workflowId,
+                                @Attribute(StepAttributes.WORKFLOW_START_TIME) String workflowStartTime) {
+            preStepHookCallCount += 1;
+        }
+
+        public int getPreStepHookCallCount() {
+            return preStepHookCallCount;
+        }
+    }
+
+    public static class TestPostStepHook implements WorkflowStepHook {
+
+        private int postStepHookCallCount = 0;
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public void postStepHook(@Attribute(StepAttributes.RESULT_CODE) String resultCode,
+                                 @Attribute(StepAttributes.ACTIVITY_COMPLETION_MESSAGE) String completionMessage) {
+            postStepHookCallCount += 1;
+        }
+
+        public int getPostStepHookCallCount() {
+            return postStepHookCallCount;
+        }
+    }
+
+    public static class TestPreAndPostStepHook implements WorkflowStepHook {
+
+        private int preStepHookCallCount = 0;
+        private int postStepHookCallCount = 0;
+
+        @StepHook(hookType = StepHook.HookType.PRE)
+        public void preStepHook() {
+            preStepHookCallCount += 1;
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public void postStepHook() {
+            postStepHookCallCount += 1;
+        }
+
+        public int getPreStepHookCallCount() {
+            return preStepHookCallCount;
+        }
+
+        public int getPostStepHookCallCount() {
+            return postStepHookCallCount;
+        }
+    }
+
+    public static class TestHookWithMetrics implements WorkflowStepHook {
+
+        public static final String PRE_HOOK_METRIC_NAME = "preHook";
+        public static final String POST_HOOK_METRIC_NAME = "postHook";
+
+        @StepHook(hookType = StepHook.HookType.PRE)
+        public void preStepHook(MetricRecorder metrics) {
+            metrics.addCount(PRE_HOOK_METRIC_NAME, 1.0);
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public void postStepHook(MetricRecorder metrics) {
+            metrics.addCount(POST_HOOK_METRIC_NAME, 1.0);
+        }
+
+    }
+
+    public static class TestPreHookThrowsExceptionNoRetryOnFailure implements WorkflowStepHook {
+        private final Throwable ex;
+
+        TestPreHookThrowsExceptionNoRetryOnFailure(Throwable ex) {
+            this.ex = ex;
+        }
+
+        @StepHook(hookType = StepHook.HookType.PRE, retryOnFailure = false)
+        public void preStepHook() throws Throwable {
+            throw ex;
+        }
+    }
+
+    public static class TestPreHookThrowsExceptionRetryOnFailure implements WorkflowStepHook {
+        private final Throwable ex;
+
+        TestPreHookThrowsExceptionRetryOnFailure(Throwable ex) {
+            this.ex = ex;
+        }
+
+        @StepHook(hookType = StepHook.HookType.PRE, retryOnFailure = true)
+        public void preStepHook() throws Throwable {
+            throw ex;
+        }
+    }
+
+    public static class TestPostHookThrowsExceptionNoRetryOnFailure implements WorkflowStepHook {
+        private final Throwable ex;
+
+        TestPostHookThrowsExceptionNoRetryOnFailure(Throwable ex) {
+            this.ex = ex;
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST, retryOnFailure = false)
+        public void postStepHook() throws Throwable {
+            throw ex;
+        }
+    }
+
+    public static class TestPostHookThrowsExceptionRetryOnFailure implements WorkflowStepHook {
+        private final Throwable ex;
+
+        TestPostHookThrowsExceptionRetryOnFailure(Throwable ex) {
+            this.ex = ex;
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST, retryOnFailure = true)
+        public void postStepHook() throws Throwable {
+            throw ex;
+        }
+    }
+}

--- a/flux-common/src/test/java/com/danielgmyers/flux/wf/graph/WorkflowGraphBuilderTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/wf/graph/WorkflowGraphBuilderTest.java
@@ -16,6 +16,7 @@
 
 package com.danielgmyers.flux.wf.graph;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -1444,13 +1445,18 @@ public class WorkflowGraphBuilderTest {
     }
 
     @Test
-    public void build_DoesValidateAttributeInputsIfInitialInputAttributesSpecified_AllowsStartTimeAttributesAsDate() {
+    public void build_DoesValidateAttributeInputsIfInitialInputAttributesSpecified_DisallowsStartTimeAttributesAsDate() {
         WorkflowStep start = new TestStepExpectsStartTimeAttributesAsDate();
 
         WorkflowGraphBuilder builder = new WorkflowGraphBuilder(start, Collections.emptyMap());
         builder.alwaysClose(start);
 
-        Assertions.assertNotNull(builder.build());
+        try {
+            builder.build();
+            Assertions.fail();
+        } catch (WorkflowGraphBuildException e) {
+            // expected
+        }
     }
 
     @Test
@@ -1523,10 +1529,30 @@ public class WorkflowGraphBuilderTest {
     }
 
     @Test
-    public void build_ValidateAttributeInputs_AllowActivityInitialTime() {
+    public void build_ValidateAttributeInputs_DisallowActivityInitialTimeAsDate() {
         WorkflowStep alwaysAllowInitialAttemptTime = new WorkflowStep() {
             @StepApply
             public void doThing(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Date initialAttemptTime) {
+            }
+        };
+
+        // note we aren't passing the activity initial attempt time attribute to the builder
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(alwaysAllowInitialAttemptTime, Collections.emptyMap());
+        builder.alwaysClose(alwaysAllowInitialAttemptTime);
+
+        try {
+            builder.build();
+            Assertions.fail();
+        } catch (WorkflowGraphBuildException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void build_ValidateAttributeInputs_AllowActivityInitialTimeAsInstant() {
+        WorkflowStep alwaysAllowInitialAttemptTime = new WorkflowStep() {
+            @StepApply
+            public void doThing(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Instant initialAttemptTime) {
             }
         };
 

--- a/flux-common/src/test/java/com/danielgmyers/flux/wf/graph/WorkflowGraphBuilder_HookTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/wf/graph/WorkflowGraphBuilder_HookTest.java
@@ -16,8 +16,8 @@
 
 package com.danielgmyers.flux.wf.graph;
 
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -479,13 +479,13 @@ public class WorkflowGraphBuilder_HookTest {
     public void hook_DoesValidateAttributeInputsIfInitialInputAttributesSpecified_AllowStepSpecificAttributes() {
         WorkflowStepHook hookWithInputAttribute = new WorkflowStepHook() {
             @StepHook(hookType = StepHook.HookType.PRE)
-            public void prehook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Date activityInitialAttemptTime,
+            public void prehook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Instant activityInitialAttemptTime,
                                 @Attribute(StepAttributes.RETRY_ATTEMPT) Long retryAttempt,
-                                @Attribute(StepAttributes.WORKFLOW_START_TIME) Date workflowStartTime) {}
+                                @Attribute(StepAttributes.WORKFLOW_START_TIME) Instant workflowStartTime) {}
             @StepHook(hookType = StepHook.HookType.POST)
-            public void posthook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Date activityInitialAttemptTime,
+            public void posthook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Instant activityInitialAttemptTime,
                                  @Attribute(StepAttributes.RETRY_ATTEMPT) Long retryAttempt,
-                                 @Attribute(StepAttributes.WORKFLOW_START_TIME) Date workflowStartTime) {}
+                                 @Attribute(StepAttributes.WORKFLOW_START_TIME) Instant workflowStartTime) {}
         };
 
         WorkflowStep one = new TestStepOne();
@@ -865,13 +865,13 @@ public class WorkflowGraphBuilder_HookTest {
     public void hookAllSteps_DoesValidateAttributeInputsIfInitialInputAttributesSpecified_AllowStepSpecificAttributes() {
         WorkflowStepHook hookWithInputAttribute = new WorkflowStepHook() {
             @StepHook(hookType = StepHook.HookType.PRE)
-            public void prehook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Date activityInitialAttemptTime,
+            public void prehook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Instant activityInitialAttemptTime,
                              @Attribute(StepAttributes.RETRY_ATTEMPT) Long retryAttempt,
-                             @Attribute(StepAttributes.WORKFLOW_START_TIME) Date workflowStartTime) {}
+                             @Attribute(StepAttributes.WORKFLOW_START_TIME) Instant workflowStartTime) {}
             @StepHook(hookType = StepHook.HookType.POST)
-            public void posthook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Date activityInitialAttemptTime,
+            public void posthook(@Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Instant activityInitialAttemptTime,
                              @Attribute(StepAttributes.RETRY_ATTEMPT) Long retryAttempt,
-                             @Attribute(StepAttributes.WORKFLOW_START_TIME) Date workflowStartTime) {}
+                             @Attribute(StepAttributes.WORKFLOW_START_TIME) Instant workflowStartTime) {}
         };
 
         WorkflowStep one = new TestStepOne();

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/DecisionTaskPoller.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/DecisionTaskPoller.java
@@ -34,6 +34,7 @@ import com.danielgmyers.flux.clients.swf.FluxCapacitorConfig;
 import com.danielgmyers.flux.clients.swf.FluxCapacitorImpl;
 import com.danielgmyers.flux.clients.swf.IdentifierValidation;
 import com.danielgmyers.flux.clients.swf.poller.timers.TimerData;
+import com.danielgmyers.flux.clients.swf.step.SwfStepInputAccessor;
 import com.danielgmyers.flux.clients.swf.util.RetryUtils;
 import com.danielgmyers.flux.ex.BadWorkflowStateException;
 import com.danielgmyers.flux.ex.UnrecognizedTaskException;
@@ -47,7 +48,7 @@ import com.danielgmyers.flux.step.PartitionedWorkflowStep;
 import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.StepResult;
 import com.danielgmyers.flux.step.WorkflowStep;
-import com.danielgmyers.flux.step.WorkflowStepUtil;
+import com.danielgmyers.flux.step.internal.WorkflowStepUtil;
 import com.danielgmyers.flux.threads.BlockOnSubmissionThreadPoolExecutor;
 import com.danielgmyers.flux.threads.ThreadUtils;
 import com.danielgmyers.flux.wf.Periodic;
@@ -484,8 +485,8 @@ public class DecisionTaskPoller implements Runnable {
             // response, which may reduce the number of partitions we could schedule.
             PartitionIdGeneratorResult result
                     = WorkflowStepUtil.getPartitionIdsForPartitionedStep((PartitionedWorkflowStep)nextStep,
-                                                                         nextStepInput, workflowName,
-                                                                         workflowId, metricsFactory);
+                                                                         new SwfStepInputAccessor(nextStepInput),
+                                                                         workflowName, workflowId, metricsFactory);
             PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(result);
 
             for (String partitionId : metadata.getPartitionIds()) {

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/WorkflowState.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/WorkflowState.java
@@ -494,14 +494,11 @@ final class WorkflowState {
                 data = event.activityTaskCompletedEventAttributes().result();
                 break;
             case ACTIVITY_TASK_TIMED_OUT:
-                data = event.activityTaskTimedOutEventAttributes().details();
-                break;
+                return Collections.emptyMap(); // Flux doesn't control the content of this event.
             case ACTIVITY_TASK_CANCELED:
-                data = event.activityTaskCanceledEventAttributes().details();
-                break;
+                return Collections.emptyMap(); // Flux doesn't populate any data in cancellation events.
             case ACTIVITY_TASK_FAILED:
-                data = null; // retries don't produce any step data.
-                break;
+                return Collections.emptyMap(); // Flux doesn't put structured data in retry events.
             default:
                 // If we get here, then someone added an entry to ACTIVITY_START_EVENTS or ACTIVITY_CLOSED_EVENTS
                 // but didn't handle it here.

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/step/SwfStepInputAccessor.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/step/SwfStepInputAccessor.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.step;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.danielgmyers.flux.step.StepAttributes;
+import com.danielgmyers.flux.step.StepInputAccessor;
+
+/**
+ * Provides access to step attributes which are stored in encoded form.
+ */
+public class SwfStepInputAccessor implements StepInputAccessor {
+
+    private Map<String, String> encodedAttributes;
+
+    public SwfStepInputAccessor(Map<String, String> encodedAttributes) {
+        this.encodedAttributes = encodedAttributes;
+    }
+
+    public SwfStepInputAccessor(String serializedInput) {
+        if (serializedInput == null || serializedInput.isBlank()) {
+            encodedAttributes = Collections.emptyMap();
+        } else {
+            encodedAttributes = StepAttributes.decode(Map.class, serializedInput);
+        }
+    }
+
+    public Map<String, String> getEncodedAttributes() {
+        return encodedAttributes;
+    }
+
+    @Override
+    public <T> T getAttribute(Class<T> requestedType, String attributeName) {
+        return StepAttributes.decode(requestedType, encodedAttributes.get(attributeName));
+    }
+}

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/util/RetryUtils.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/util/RetryUtils.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 import com.danielgmyers.flux.clients.swf.FluxCapacitorImpl;
 import com.danielgmyers.flux.step.StepApply;
 import com.danielgmyers.flux.step.WorkflowStep;
-import com.danielgmyers.flux.step.WorkflowStepUtil;
+import com.danielgmyers.flux.step.internal.WorkflowStepUtil;
 import com.danielgmyers.metrics.MetricRecorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/ActivityExecutorTest.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/ActivityExecutorTest.java
@@ -23,27 +23,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.danielgmyers.flux.clients.swf.FluxCapacitorImpl;
-import com.danielgmyers.flux.clients.swf.poller.testwf.TestHookWithMetrics;
-import com.danielgmyers.flux.clients.swf.poller.testwf.TestPostStepHook;
-import com.danielgmyers.flux.clients.swf.poller.testwf.TestPreAndPostStepHook;
-import com.danielgmyers.flux.clients.swf.poller.testwf.TestPreStepHook;
 import com.danielgmyers.flux.clients.swf.poller.testwf.TestWorkflow;
-import com.danielgmyers.flux.poller.ActivityExecutionUtil;
 import com.danielgmyers.flux.poller.TaskNaming;
-import com.danielgmyers.flux.step.Attribute;
-import com.danielgmyers.flux.step.StepApply;
 import com.danielgmyers.flux.step.StepAttributes;
-import com.danielgmyers.flux.step.StepHook;
 import com.danielgmyers.flux.step.StepResult;
-import com.danielgmyers.flux.step.WorkflowStep;
-import com.danielgmyers.flux.step.WorkflowStepHook;
-import com.danielgmyers.flux.step.WorkflowStepUtil;
-import com.danielgmyers.flux.wf.Workflow;
-import com.danielgmyers.flux.wf.graph.PostWorkflowHookAnchor;
-import com.danielgmyers.flux.wf.graph.PreWorkflowHookAnchor;
-import com.danielgmyers.flux.wf.graph.WorkflowGraph;
-import com.danielgmyers.flux.wf.graph.WorkflowGraphBuilder;
-import com.danielgmyers.metrics.MetricRecorder;
+import com.danielgmyers.flux.step.internal.ActivityExecutionUtil;
 import com.danielgmyers.metrics.recorders.InMemoryMetricRecorder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +40,6 @@ import software.amazon.awssdk.services.swf.model.WorkflowExecution;
 public class ActivityExecutorTest {
 
     private static final String IDENTITY = "unit";
-    private static final String STEP_NAME = "DummyWorkflow.DummyStep";
     private static final String TASK_TOKEN = "task-token";
 
     private ActivityTaskPollerTest.DummyStep step;
@@ -67,77 +50,7 @@ public class ActivityExecutorTest {
     public void setup() {
         step = new ActivityTaskPollerTest.DummyStep();
         fluxMetrics = new InMemoryMetricRecorder("ActivityExecutor");
-        stepMetrics = new InMemoryMetricRecorder(STEP_NAME);
-    }
-
-    @Test
-    public void appliesStepIfInputIsNull() {
-        PollForActivityTaskResponse task = makeTask(null, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        Map<String, String> output = Collections.emptyMap();
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertTrue(step.didThing());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Map<String, String> fullOutput = new HashMap<>(output);
-        fullOutput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-        fullOutput.put(StepAttributes.RESULT_CODE, result.getResultCode());
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(result, executor.getResult());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                                                                                                      result.getResultCode())).intValue());
-    }
-
-    @Test
-    public void appliesStepIfInputIsEmptyMap() {
-        Map<String, String> input = Collections.emptyMap();
-        Map<String, String> output = Collections.emptyMap();
-
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertTrue(step.didThing());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-        fullOutput.put(StepAttributes.RESULT_CODE, result.getResultCode());
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(result, executor.getResult());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                result.getResultCode())).intValue());
+        stepMetrics = new InMemoryMetricRecorder(TaskNaming.activityName(TestWorkflow.class, ActivityTaskPollerTest.DummyStep.class));
     }
 
     @Test
@@ -145,7 +58,8 @@ public class ActivityExecutorTest {
         Map<String, String> input = new HashMap<>();
         Map<String, String> output = Collections.emptyMap();
 
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
+        String activityName = TaskNaming.activityName(TestWorkflow.class, ActivityTaskPollerTest.DummyStep.class);
+        PollForActivityTaskResponse task = makeTask(input, activityName);
         ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
 
         StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
@@ -158,17 +72,20 @@ public class ActivityExecutorTest {
         // We need to close it so we can query its data.
         fluxMetrics.close();
 
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-        fullOutput.put(StepAttributes.RESULT_CODE, result.getResultCode());
+        Map<String, String> expectedOutputContent = new HashMap<>();
+        expectedOutputContent.putAll(input);
+        expectedOutputContent.putAll(output);
+        expectedOutputContent.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
+        expectedOutputContent.put(StepAttributes.RESULT_CODE, result.getResultCode());
 
         Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
+        Assertions.assertEquals(expectedOutputContent, StepAttributes.decode(Map.class, executor.getOutput()));
 
         Assertions.assertNotNull(executor.getResult());
         Assertions.assertEquals(result, executor.getResult());
+
+        Assertions.assertTrue(fluxMetrics.isClosed());
+        Assertions.assertTrue(stepMetrics.isClosed());
 
         Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
         Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
@@ -181,7 +98,8 @@ public class ActivityExecutorTest {
     public void returnsRetryWhenApplyReturnsRetry() {
         Map<String, String> input = new HashMap<>();
 
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
+        String activityName = TaskNaming.activityName(TestWorkflow.class, ActivityTaskPollerTest.DummyStep.class);
+        PollForActivityTaskResponse task = makeTask(input, activityName);
         ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
 
         StepResult result = makeStepResult(StepResult.ResultAction.RETRY, null, "hmm", Collections.emptyMap());
@@ -199,6 +117,9 @@ public class ActivityExecutorTest {
         Assertions.assertNotNull(executor.getResult());
         Assertions.assertEquals(result, executor.getResult());
 
+        Assertions.assertTrue(fluxMetrics.isClosed());
+        Assertions.assertTrue(stepMetrics.isClosed());
+
         Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
         Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
 
@@ -210,7 +131,8 @@ public class ActivityExecutorTest {
     public void returnsRetryWhenApplyThrowsException() {
         Map<String, String> input = new HashMap<>();
 
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
+        String activityName = TaskNaming.activityName(TestWorkflow.class, ActivityTaskPollerTest.DummyStep.class);
+        PollForActivityTaskResponse task = makeTask(input, activityName);
         ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
 
         RuntimeException e = new RuntimeException("message!");
@@ -233,601 +155,14 @@ public class ActivityExecutorTest {
         Assertions.assertNotNull(executor.getResult());
         Assertions.assertEquals(StepResult.ResultAction.RETRY, executor.getResult().getAction());
 
+        Assertions.assertTrue(fluxMetrics.isClosed());
+        Assertions.assertTrue(stepMetrics.isClosed());
+
         Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
         Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
 
         Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatRetryResultMetricName(task.activityType().name(),
                                 e.getClass().getSimpleName())).intValue());
-    }
-
-    @Test
-    public void properlyMapsAttributesToParameters() {
-        String stringParam = "foo";
-        Long longParam = 42L;
-        Boolean booleanParam = true;
-        Map<String, String> stringMap = new HashMap<>();
-        stringMap.put("bar", "baz");
-        stringMap.put("zap", null);
-
-        StubStep stub = new StubStep();
-        stub.setExpectedString(stringParam);
-        stub.setExpectedLong(longParam);
-        stub.setExpectedBoolean(booleanParam);
-        stub.setExpectedStringMap(stringMap);
-
-        Map<String, String> input = new HashMap<>();
-        input.put(StubStep.STRING_PARAM, StepAttributes.encode(stringParam));
-        input.put(StubStep.LONG_PARAM, StepAttributes.encode(longParam));
-        input.put(StubStep.BOOLEAN_PARAM, StepAttributes.encode(booleanParam));
-        input.put(StubStep.STRING_MAP_PARAM, StepAttributes.encode(stringMap));
-
-        String activityName = "stepName";
-
-        // The stub step has a return type of void, so it should always just be a plain success result.
-        Assertions.assertEquals(StepResult.success(), ActivityExecutionUtil.executeActivity(stub, activityName, fluxMetrics, stepMetrics, input));
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(activityName,
-                                StepResult.SUCCEED_RESULT_CODE)).intValue());
-    }
-
-    public static class StepWithMetrics implements WorkflowStep {
-
-        private final String metricName;
-
-        public StepWithMetrics(String metricName) {
-            this.metricName = metricName;
-        }
-        @StepApply
-        public void doThing(MetricRecorder metrics) {
-            metrics.addCount(metricName, 1.0);
-        }
-    }
-
-    @Test
-    public void passesInStepMetrics() {
-        final String stepMetric = "foo";
-
-        WorkflowStep stepWithMetrics = new StepWithMetrics(stepMetric);
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(stepWithMetrics);
-        builder.alwaysClose(stepWithMetrics);
-
-        String activityName = "stepName";
-
-        // The stub step has a return type of void, so it should always just be a plain success result.
-        Assertions.assertEquals(StepResult.success(), ActivityExecutionUtil.executeActivity(stepWithMetrics, activityName, fluxMetrics, stepMetrics, Collections.emptyMap()));
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        // stepMetrics is usually closed by the ActivityTaskExecutor, outside the executeActivity call.
-        // We need to close it so we can query its data.
-        stepMetrics.close();
-
-        Assertions.assertTrue(stepMetrics.getCounts().containsKey(stepMetric));
-        Assertions.assertEquals(1, stepMetrics.getCounts().get(stepMetric).longValue());
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(activityName,
-                                StepResult.SUCCEED_RESULT_CODE)).intValue());
-    }
-
-    @Test
-    public void runsPreAndPostHooksForStep() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        TestPreStepHook hook = new TestPreStepHook();
-        TestPostStepHook hook2 = new TestPostStepHook();
-        TestPreAndPostStepHook hook3 = new TestPreAndPostStepHook();
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addStepHook(step, hook);
-        builder.addStepHook(step, hook2);
-        builder.addStepHook(step, hook3);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertTrue(step.didThing());
-        Assertions.assertEquals(1, hook.getPreStepHookCallCount());
-        Assertions.assertEquals(1, hook2.getPostStepHookCallCount());
-        Assertions.assertEquals(1, hook3.getPreStepHookCallCount());
-        Assertions.assertEquals(1, hook3.getPostStepHookCallCount());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-        fullOutput.put(StepAttributes.RESULT_CODE, result.getResultCode());
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(result, executor.getResult());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreStepHook.class.getSimpleName(),
-                "preStepHook", task.activityType().name())));
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostStepHook.class.getSimpleName(),
-                "postStepHook", task.activityType().name())));
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
-                "preStepHook", task.activityType().name())));
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
-                "postStepHook", task.activityType().name())));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                result.getResultCode())).intValue());
-    }
-
-    @Test
-    public void runsPreAndPostHooksForStep_PassInHookMetrics() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        WorkflowStepHook metricsHook = new TestHookWithMetrics();
-
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addStepHook(step, metricsHook);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertTrue(step.didThing());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Assertions.assertTrue(stepMetrics.isClosed());
-        Assertions.assertTrue(stepMetrics.getCounts().containsKey(TestHookWithMetrics.PRE_HOOK_METRIC_NAME));
-        Assertions.assertTrue(stepMetrics.getCounts().containsKey(TestHookWithMetrics.POST_HOOK_METRIC_NAME));
-        Assertions.assertEquals(1, stepMetrics.getCounts().get(TestHookWithMetrics.PRE_HOOK_METRIC_NAME).longValue());
-        Assertions.assertEquals(1, stepMetrics.getCounts().get(TestHookWithMetrics.POST_HOOK_METRIC_NAME).longValue());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-        fullOutput.put(StepAttributes.RESULT_CODE, result.getResultCode());
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(result, executor.getResult());
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestHookWithMetrics.class.getSimpleName(),
-                "preStepHook", task.activityType().name())));
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestHookWithMetrics.class.getSimpleName(),
-                "postStepHook", task.activityType().name())));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                result.getResultCode())).intValue());
-    }
-
-    @Test
-    public void runsOnlyPreHooksForPreWorkflowHookAnchor() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        TestPreStepHook hook = new TestPreStepHook();
-        TestPostStepHook hook2 = new TestPostStepHook();
-        TestPreAndPostStepHook hook3 = new TestPreAndPostStepHook();
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addWorkflowHook(hook);
-        builder.addWorkflowHook(hook2);
-        builder.addWorkflowHook(hook3);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        WorkflowStep anchorStep = workflow.getGraph().getFirstStep();
-        Assertions.assertEquals(PreWorkflowHookAnchor.class, anchorStep.getClass());
-
-        PollForActivityTaskResponse task = makeTask(input, TaskNaming.activityName(TaskNaming.workflowName(workflow.getClass()), anchorStep));
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, anchorStep, fluxMetrics,  (o, c) -> stepMetrics);
-
-        executor.run();
-        Assertions.assertEquals(1, hook.getPreStepHookCallCount());
-        Assertions.assertEquals(0, hook2.getPostStepHookCallCount());
-        Assertions.assertEquals(1, hook3.getPreStepHookCallCount());
-        Assertions.assertEquals(0, hook3.getPostStepHookCallCount());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.RESULT_CODE, StepResult.SUCCEED_RESULT_CODE);
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(StepResult.success(), executor.getResult());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreStepHook.class.getSimpleName(),
-                "preStepHook", task.activityType().name())));
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
-                "preStepHook", task.activityType().name())));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                StepResult.SUCCEED_RESULT_CODE)).intValue());
-    }
-
-    @Test
-    public void runsOnlyPostHooksForPostWorkflowHookAnchor() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        TestPreStepHook hook = new TestPreStepHook();
-        TestPostStepHook hook2 = new TestPostStepHook();
-        TestPreAndPostStepHook hook3 = new TestPreAndPostStepHook();
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addWorkflowHook(hook);
-        builder.addWorkflowHook(hook2);
-        builder.addWorkflowHook(hook3);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        Assertions.assertNotNull(workflow.getGraph().getNodes().get(PostWorkflowHookAnchor.class));
-        WorkflowStep anchorStep = workflow.getGraph().getNodes().get(PostWorkflowHookAnchor.class).getStep();
-        Assertions.assertNotNull(anchorStep);
-
-        PollForActivityTaskResponse task = makeTask(input, TaskNaming.activityName(TaskNaming.workflowName(workflow.getClass()), anchorStep));
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, anchorStep, fluxMetrics,  (o, c) -> stepMetrics);
-
-        executor.run();
-        Assertions.assertEquals(0, hook.getPreStepHookCallCount());
-        Assertions.assertEquals(1, hook2.getPostStepHookCallCount());
-        Assertions.assertEquals(0, hook3.getPreStepHookCallCount());
-        Assertions.assertEquals(1, hook3.getPostStepHookCallCount());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.RESULT_CODE, StepResult.SUCCEED_RESULT_CODE);
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(StepResult.success(), executor.getResult());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostStepHook.class.getSimpleName(),
-                "postStepHook", task.activityType().name())));
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreAndPostStepHook.class.getSimpleName(),
-                "postStepHook", task.activityType().name())));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                StepResult.SUCCEED_RESULT_CODE)).intValue());
-    }
-
-    public static class TestPreHookThrowsExceptionNoRetryOnFailure implements WorkflowStepHook {
-        private final Throwable ex;
-
-        TestPreHookThrowsExceptionNoRetryOnFailure(Throwable ex) {
-            this.ex = ex;
-        }
-
-        @StepHook(hookType = StepHook.HookType.PRE, retryOnFailure = false)
-        public void preStepHook() throws Throwable {
-            throw ex;
-        }
-    }
-
-    public static class TestPreHookThrowsExceptionRetryOnFailure implements WorkflowStepHook {
-        private final Throwable ex;
-
-        TestPreHookThrowsExceptionRetryOnFailure(Throwable ex) {
-            this.ex = ex;
-        }
-
-        @StepHook(hookType = StepHook.HookType.PRE, retryOnFailure = true)
-        public void preStepHook() throws Throwable {
-            throw ex;
-        }
-    }
-
-    public static class TestPostHookThrowsExceptionNoRetryOnFailure implements WorkflowStepHook {
-        private final Throwable ex;
-
-        TestPostHookThrowsExceptionNoRetryOnFailure(Throwable ex) {
-            this.ex = ex;
-        }
-
-        @StepHook(hookType = StepHook.HookType.POST, retryOnFailure = false)
-        public void postStepHook() throws Throwable {
-            throw ex;
-        }
-    }
-
-    public static class TestPostHookThrowsExceptionRetryOnFailure implements WorkflowStepHook {
-        private final Throwable ex;
-
-        TestPostHookThrowsExceptionRetryOnFailure(Throwable ex) {
-            this.ex = ex;
-        }
-
-        @StepHook(hookType = StepHook.HookType.POST, retryOnFailure = true)
-        public void postStepHook() throws Throwable {
-            throw ex;
-        }
-    }
-
-    @Test
-    public void ignoresFailureInPreHook_HookRetryOnFailureDisabled() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        RuntimeException e = new RuntimeException("Wheeee!");
-        WorkflowStepHook hook = new TestPreHookThrowsExceptionNoRetryOnFailure(e);
-
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addStepHook(step, hook);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertTrue(step.didThing());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-        fullOutput.put(StepAttributes.RESULT_CODE, result.getResultCode());
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(result, executor.getResult());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreHookThrowsExceptionNoRetryOnFailure.class.getSimpleName(),
-                "preStepHook", task.activityType().name())));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                result.getResultCode())).intValue());
-    }
-
-    @Test
-    public void retryOnFailureInPreHook_HookRetryOnFailureEnabled() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        RuntimeException e = new RuntimeException("Wheeee!");
-        WorkflowStepHook hook = new TestPreHookThrowsExceptionRetryOnFailure(e);
-
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addStepHook(step, hook);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertFalse(step.didThing()); // false because the pre-hook required a retry on failure, so the step never ran
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Assertions.assertNull(executor.getOutput()); // null because retry doesn't support output attributes, and there was no exception stack trace to record
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(StepResult.ResultAction.RETRY, executor.getResult().getAction());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPreHookThrowsExceptionRetryOnFailure.class.getSimpleName(),
-                "preStepHook", task.activityType().name())));
-    }
-
-    @Test
-    public void ignoresFailureInPostHook_HookRetryOnFailureDisabled() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        RuntimeException e = new RuntimeException("Wheeee!");
-        WorkflowStepHook hook = new TestPostHookThrowsExceptionNoRetryOnFailure(e);
-
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addStepHook(step, hook);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertTrue(step.didThing());
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Map<String, String> fullOutput = new HashMap<>();
-        fullOutput.putAll(input);
-        fullOutput.putAll(output);
-        fullOutput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-        fullOutput.put(StepAttributes.RESULT_CODE, result.getResultCode());
-
-        Assertions.assertNotNull(executor.getOutput());
-        Assertions.assertEquals(fullOutput, StepAttributes.decode(Map.class, executor.getOutput()));
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(result, executor.getResult());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostHookThrowsExceptionNoRetryOnFailure.class.getSimpleName(),
-                "postStepHook", task.activityType().name())));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                result.getResultCode())).intValue());
-    }
-
-    @Test
-    public void retryOnFailureInPostHook_HookRetryOnFailureEnabled() {
-        Map<String, String> input = new HashMap<>();
-        Map<String, String> output = Collections.emptyMap();
-
-        RuntimeException e = new RuntimeException("Wheeee!");
-        WorkflowStepHook hook = new TestPostHookThrowsExceptionRetryOnFailure(e);
-
-        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
-        builder.alwaysClose(step);
-        builder.addStepHook(step, hook);
-
-        Workflow workflow = new Workflow() {
-            private final WorkflowGraph graph = builder.build();
-
-            @Override
-            public WorkflowGraph getGraph() {
-                return graph;
-            }
-        };
-
-        PollForActivityTaskResponse task = makeTask(input, STEP_NAME);
-        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, workflow, step, fluxMetrics,  (o, c) -> stepMetrics);
-
-        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
-        step.setStepResult(result);
-
-        executor.run();
-        Assertions.assertTrue(step.didThing()); // true because we did the thing
-
-        // fluxMetrics is usually closed by the ActivityTaskPoller.
-        // We need to close it so we can query its data.
-        fluxMetrics.close();
-
-        Assertions.assertNull(executor.getOutput()); // null because retry doesn't support output attributes, and there was no exception stack trace to record
-
-        Assertions.assertNotNull(executor.getResult());
-        Assertions.assertEquals(StepResult.ResultAction.RETRY, executor.getResult().getAction());
-
-        Assertions.assertEquals(task.workflowExecution().workflowId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
-        Assertions.assertEquals(task.workflowExecution().runId(), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
-
-        Assertions.assertTrue(fluxMetrics.getDurations().containsKey(WorkflowStepUtil.formatHookExecutionTimeName(TestPostHookThrowsExceptionRetryOnFailure.class.getSimpleName(),
-                "postStepHook", task.activityType().name())));
-
-        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(task.activityType().name(),
-                                result.getResultCode())).intValue());
     }
 
     private PollForActivityTaskResponse makeTask(Map<String, String> input, String stepName) {
@@ -842,56 +177,6 @@ public class ActivityExecutorTest {
 
     private StepResult makeStepResult(StepResult.ResultAction resultAction, String stepResult, String message, Map<String, String> output) {
         return new StepResult(resultAction, stepResult, message).withAttributes(output);
-    }
-
-    public static class StubStep implements WorkflowStep {
-
-        public static final String STRING_PARAM = "someStringValue";
-        public static final String LONG_PARAM = "someLongValue";
-        public static final String BOOLEAN_PARAM = "someBooleanValue";
-        public static final String STRING_MAP_PARAM = "someStringMap";
-
-        private String expectedString;
-        private Long expectedLong;
-        private Boolean expectedBoolean;
-        private Map<String, String> expectedStringMap;
-
-        @StepApply
-        public void apply(@Attribute(STRING_PARAM) String stringParam,
-                          @Attribute(LONG_PARAM) Long longParam,
-                          @Attribute(BOOLEAN_PARAM) Boolean booleanParam,
-                          @Attribute(STRING_MAP_PARAM) Map<String, String> stringMap,
-                          @Attribute("ThisShouldBeNull") String nullParam,
-                          @Attribute("ThisShouldBeEmpty") Map<String, String> emptyMapParam) {
-            Assertions.assertNotNull(stringParam);
-            Assertions.assertNotNull(longParam);
-            Assertions.assertNotNull(booleanParam);
-            Assertions.assertNotNull(stringMap);
-            Assertions.assertNull(nullParam);
-            Assertions.assertNotNull(emptyMapParam);
-
-            Assertions.assertEquals(expectedString, stringParam);
-            Assertions.assertEquals(expectedLong, longParam);
-            Assertions.assertEquals(expectedBoolean, booleanParam);
-            Assertions.assertEquals(expectedStringMap, stringMap);
-            Assertions.assertTrue(emptyMapParam.isEmpty());
-        }
-
-        public void setExpectedString(String expectedString) {
-            this.expectedString = expectedString;
-        }
-
-        public void setExpectedLong(Long expectedLong) {
-            this.expectedLong = expectedLong;
-        }
-
-        public void setExpectedBoolean(Boolean expectedBoolean) {
-            this.expectedBoolean = expectedBoolean;
-        }
-
-        public void setExpectedStringMap(Map<String, String> expectedStringMap) {
-            this.expectedStringMap = expectedStringMap;
-        }
     }
 
 }

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/ActivityTaskPollerTest.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/ActivityTaskPollerTest.java
@@ -29,12 +29,12 @@ import javax.net.ssl.SSLException;
 
 import com.danielgmyers.flux.clients.swf.FluxCapacitorImpl;
 import com.danielgmyers.flux.ex.UnrecognizedTaskException;
-import com.danielgmyers.flux.poller.ActivityExecutionUtil;
 import com.danielgmyers.flux.poller.TaskNaming;
 import com.danielgmyers.flux.step.StepApply;
 import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.StepResult;
 import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.step.internal.ActivityExecutionUtil;
 import com.danielgmyers.flux.threads.BlockOnSubmissionThreadPoolExecutor;
 import com.danielgmyers.flux.wf.Workflow;
 import com.danielgmyers.flux.wf.graph.WorkflowGraph;

--- a/flux-testutils/src/test/java/com/danielgmyers/flux/testutil/StepValidatorTest.java
+++ b/flux-testutils/src/test/java/com/danielgmyers/flux/testutil/StepValidatorTest.java
@@ -17,10 +17,13 @@
 package com.danielgmyers.flux.testutil;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.danielgmyers.flux.step.Attribute;
 import com.danielgmyers.flux.step.StepApply;
+import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.StepResult;
 import com.danielgmyers.flux.step.WorkflowStep;
 import org.junit.jupiter.api.Assertions;
@@ -148,7 +151,12 @@ public class StepValidatorTest {
         }
 
         @StepApply
-        public StepResult apply() {
+        public StepResult apply(@Attribute(StepAttributes.WORKFLOW_ID) String workflowId,
+                                @Attribute(StepAttributes.WORKFLOW_EXECUTION_ID) String workflowExecutionId,
+                                @Attribute(StepAttributes.WORKFLOW_START_TIME) Instant workflowStartTime) {
+            Assertions.assertNotNull(workflowId);
+            Assertions.assertNotNull(workflowExecutionId);
+            Assertions.assertNotNull(workflowStartTime);
             return applyResult;
         }
     }


### PR DESCRIPTION
Move all of the non-SWF-specific bits of flux-swf's ActivityExecutor to flux-common's ActivityExecutionUtil.
In particular, this will allow reuse of the pre- and post-hook execution logic for other backend implementations.

ActivityExecutionUtil and WorkflowStepUtil now take a StepInputAccessor object as the mechanism for accessing
step attributes, rather than assuming all implementations can provide a Map<String, ?> with any particular
encoding mechanism.

WorkflowStepHook inputs are still provided via Map<String, Object> since those are all generated on the fly.

When providing step inputs, Flux no longer automatically provides a mutable, empty HashMap if the requested
attribute is null or an empty string. This allows users to tell the difference between "a previous step did
not provide this attribute" and "a previous step provided an empty map".

Flux no longer guarantees that Date attributes provided by one step will be automatically converted to
Instant if a later step requests it as an Instant, and vice versa, including for the built-in attributes.
(This will still work for user-provided attributes for the time being, but that is no longer guaranteed.)
Additionally, support for the Date type as a step attribute is now documented as deprecated.

Other minor changes:
* Moved ActivityExecutionUtil from `com.danielgmyers.flux.poller` to `com.danielgmyers.flux.step.internal`
* Moved WorkflowStepUtil from `com.danielgmyers.flux.step` to `com.danielgmyers.flux.step.internal`
* Added an AttributeTypeMismatchException to be thrown if the attribute type requested by a workflow step
  does not match the actual attribute type found in the step attribute metadata. For the current SWF
  implementation this will in practice only happen for WorkflowStepHooks, since we don't actually know
  the type of the regular step attributes before we try to deserialize them as the requested type.
* flux-testutils' StepValidator no longer encodes the provided input attributes only for ActivityExecutionUtil
  to immediately decode the same attributes, by providing its own StepInputAccessor.
