### PR TITLE
Fix issue with periodic workflow submitter pool potentially dropping its scheduled tasks.

### DIFF
--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <artifactId>flux-common</artifactId>
     <name>Flux SWF Client Common</name>

--- a/flux-common/src/test/java/software/amazon/aws/clients/swf/flux/step/StepAttributesTest.java
+++ b/flux-common/src/test/java/software/amazon/aws/clients/swf/flux/step/StepAttributesTest.java
@@ -18,6 +18,7 @@ package software.amazon.aws.clients.swf.flux.step;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -126,7 +127,9 @@ public class StepAttributesTest {
 
         // we want the encoded form to be decodeable as either class
         Assert.assertEquals(date, StepAttributes.decode(Date.class, date_encoded));
-        Assert.assertEquals(now, StepAttributes.decode(Instant.class, date_encoded));
+
+        // the serialized form is truncated to millis, so we need to truncate our local object for comparison.
+        Assert.assertEquals(now.truncatedTo(ChronoUnit.MILLIS), StepAttributes.decode(Instant.class, date_encoded));
     }
 
     @Test

--- a/flux-guice/pom.xml
+++ b/flux-guice/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <artifactId>flux-guice</artifactId>
     <name>Flux SWF Client Guice Helper</name>

--- a/flux-integration-tests/pom.xml
+++ b/flux-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <artifactId>flux-integration-tests</artifactId>
     <name>Flux SWF Client integration tests</name>

--- a/flux-spring/pom.xml
+++ b/flux-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <artifactId>flux-spring</artifactId>
     <name>Flux SWF Client Spring Helper</name>

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <artifactId>flux-testutils</artifactId>
     <name>Flux SWF Client Test Utils</name>

--- a/flux/pom.xml
+++ b/flux/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.danielgmyers.flux.clients.swf</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <artifactId>flux</artifactId>
     <name>Flux SWF Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf-client-pom</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.9</version>
     <packaging>pom</packaging>
     <name>Flux SWF Client POM</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>


### PR DESCRIPTION
- **Use the same configuration for the periodic workflow submitter's thread pool as for the worker pools.**

The worker pools use an exception-swallowing wrapper around the `Runnable` so that if the runnable throws an exception, it doesn't cause the `ScheduledExecutorService` to stop rescheduling the task. They also suppress the stack trace from being printed to stdout.

This change uses that same configuration for the periodic workflow submitter.

- **Bump version to 2.0.9.**
