### PR TITLE
Bump build systems to java 17. Upgrade Spring.

### DIFF
--- a/buildspec/build-and-publish.yml
+++ b/buildspec/build-and-publish.yml
@@ -10,7 +10,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: corretto17
   pre_build:
     commands:
       - mkdir -p ~/.m2/

--- a/buildspec/build-and-stage.yml
+++ b/buildspec/build-and-stage.yml
@@ -10,7 +10,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: corretto17
   pre_build:
     commands:
       - mkdir -p ~/.m2/

--- a/buildspec/build.yml
+++ b/buildspec/build.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: corretto17
   build:
     commands:
       - mvn integration-test

--- a/flux-swf-spring/README.md
+++ b/flux-swf-spring/README.md
@@ -2,7 +2,7 @@
 Library initialization with Spring
 ------------------------------------
 
-You'll need a dependency on `flux-spring` to make use of this example config.
+You'll need a dependency on `flux-swf-spring` to make use of this example config.
 
 If you're using Spring, it is recommended to initialize your Workflow objects as singleton beans, either via component-scan or xml configuration.
 
@@ -10,21 +10,16 @@ If you're using Spring, it is recommended to initialize your Workflow objects as
 <beans>
     <!-- This assumes you have the following beans initialized:
         - MetricRecorderFactory - an object implementing the MetricRecorderFactory interface.
-        - AWSCredentials - an AWSCredentialsProvider object with your credentials in it.
-        - swfRegion - a String containing the swf region you want to use.
-        - swfEndpoint - a String containing the swf endpoint Flux should connect to.
-        - workflowDomain - a String containing the workflow domain Flux should use to register and execute workflows.
-        
+        - AwsCredentialsProvider - an AwsCredentialsProvider object with your credentials in it.
+        - config - a FluxCapacitorConfig object containing the desired configuration.
+
         This also assumes your Spring context contains a list of objects implementing the Workflow interface,
         which will be autowired into the FluxSpringInitializer bean.
     -->
-
     <bean id="fluxFactory" class="com.danielgmyers.flux.clients.swf.spring.FluxSpringCreator" factory-method="createWithConfig">
         <constructor-arg ref="MetricRecorderFactory" />
-        <constructor-arg ref="AWSCredentials" />
-        <constructor-arg ref="swfRegion" />
-        <constructor-arg ref="swfEndpoint" />
-        <constructor-arg ref="workflowDomain" />
+        <constructor-arg ref="AwsCredentialsProvider" />
+        <constructor-arg ref="config" />
     </bean>
     <bean id="fluxCapacitor" factory-bean="fluxFactory" factory-method="create" />
     <bean id="fluxInitializer" class="com.danielgmyers.flux.clients.swf.spring.FluxSpringInitializer" />

--- a/flux-swf-spring/pom.xml
+++ b/flux-swf-spring/pom.xml
@@ -24,13 +24,15 @@
 
     <properties>
         <skip.deploy>false</skip.deploy>
+
+        <spring.version>6.2.3</spring.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>5.3.23</version>
+            <version>${spring.version}</version>
         </dependency>
 
         <!-- flux internal dependencies -->
@@ -42,6 +44,24 @@
         </dependency>
 
         <!-- test dependencies -->
+        <dependency>
+            <groupId>com.danielgmyers.flux</groupId>
+            <artifactId>flux-testutils</artifactId>
+            <version>${flux.base.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/flux-swf-spring/src/test/java/com/danielgmyers/flux/clients/swf/spring/SpringInitializationTest.java
+++ b/flux-swf-spring/src/test/java/com/danielgmyers/flux/clients/swf/spring/SpringInitializationTest.java
@@ -1,0 +1,44 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.spring;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.danielgmyers.flux.FluxCapacitor;
+import com.danielgmyers.flux.testutil.StubFluxCapacitor;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = {"/test-context.xml"})
+public class SpringInitializationTest {
+
+    @Autowired
+    FluxCapacitor fluxCapacitor;
+
+    @Test
+    public void testInitialization() {
+        // The content of test-context.xml is technically part of this test.
+        // We're verifying that FluxSpringCreator and FluxSpringInitializer, when used as described in the README,
+        // produce a valid FluxCapacitor bean.
+        Assertions.assertNotNull(fluxCapacitor);
+        Assertions.assertInstanceOf(StubFluxCapacitor.class, fluxCapacitor);
+    }
+}

--- a/flux-swf-spring/src/test/java/com/danielgmyers/flux/clients/swf/spring/TestWorkflow.java
+++ b/flux-swf-spring/src/test/java/com/danielgmyers/flux/clients/swf/spring/TestWorkflow.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.spring;
+
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.flux.wf.graph.WorkflowGraph;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphBuilder;
+
+public class TestWorkflow implements Workflow {
+    @Override
+    public WorkflowGraph getGraph() {
+        WorkflowStep step = new TestWorkflowStep();
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+
+        return builder.build();
+    }
+}

--- a/flux-swf-spring/src/test/java/com/danielgmyers/flux/clients/swf/spring/TestWorkflowStep.java
+++ b/flux-swf-spring/src/test/java/com/danielgmyers/flux/clients/swf/spring/TestWorkflowStep.java
@@ -1,0 +1,27 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.swf.spring;
+
+import com.danielgmyers.flux.step.StepApply;
+import com.danielgmyers.flux.step.WorkflowStep;
+
+public class TestWorkflowStep implements WorkflowStep {
+
+    @StepApply
+    public void doNothing() {
+    }
+}

--- a/flux-swf-spring/src/test/resources/test-context.xml
+++ b/flux-swf-spring/src/test/resources/test-context.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="MetricRecorderFactory" class="com.danielgmyers.metrics.recorders.NoopMetricRecorderFactory" />
+    <bean id="AwsCredentialsProvider" class="software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider" factory-method="create" />
+    <bean id="config" class="com.danielgmyers.flux.clients.swf.FluxCapacitorConfig" />
+
+    <bean id="fluxFactory" class="com.danielgmyers.flux.clients.swf.spring.FluxSpringCreator" factory-method="createWithConfig">
+        <constructor-arg ref="MetricRecorderFactory" />
+        <constructor-arg ref="AwsCredentialsProvider" />
+        <constructor-arg ref="config" />
+    </bean>
+
+    <!-- Flux won't initialize if there are no Workflow objects -->
+    <bean id="TestWorkflow" class="com.danielgmyers.flux.clients.swf.spring.TestWorkflow" />
+
+    <bean id="fluxCapacitor" class="com.danielgmyers.flux.testutil.StubFluxCapacitor" />
+    <bean id="fluxInitializer" class="com.danielgmyers.flux.clients.swf.spring.FluxSpringInitializer" />
+</beans>


### PR DESCRIPTION
Bump the build system's java version to 17, but still target java 11 bytecode. This lets us build with the latest Spring, which targets java 17 bytecode.
https://github.com/danielgmyers/flux-swf-client/issues/149

Upgrade the Spring dependency for flux-swf-spring to 6.2.3.
Add a unit test for the spring initialization helpers.
Update the README for flux-swf-spring so it's accurate for flux 2.1.