### PR TITLE
[flux-sfn] Copy of IdentifierValidation for Step Functions.

### DIFF
--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/IdentifierValidation.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/IdentifierValidation.java
@@ -1,0 +1,136 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn;
+
+import java.util.regex.Pattern;
+
+import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.wf.Workflow;
+
+/**
+ * Step Functions has a service-side limit of 80 characters on the identifiers listed here unless otherwise noted.
+ *
+ * On startup, we register:
+ * 1) State Machines, which we generate using the class names of the Workflow implementations.
+ * 2) Activities, which we generate by appending the WorkflowStep class names to their corresponding Workflow class names,
+ *    separated by a dash. (This way, if a step is reused across workflows, it gets a different ActivityType for each workflow.)
+ *
+ * State machine names are generated using the underlying Workflow class name. However, activity names also use the Workflow name
+ * as part of their name, so we need to limit workflow names by how long they can be when part of activity names.
+ *
+ * Activity names are limited to 80 characters, and that space is split between the Workflow and WorkflowStep class name,
+ * with a dash character between them. If we split the remaining 79 characters evenly between Workflow and WorkflowStep names,
+ * that allows the Workflow and WorkflowStep implementation class names to be 39 characters long.
+ *
+ * When polling for work, we use the current host's hostname as part of the poller's identity, along with a Flux-specified
+ * small integer (between 0 and the poller thread pool size). While we could include the activity name in the poller identity,
+ * polling is explicitly per-activity anyway so there's not much value in that. The poller thread pool should be only a few threads
+ * since we don't need to poll with as many threads as we have active workers, but if we pessimistically reserve four characters
+ * for a separator and the thread number, that leaves 77 characters for the hostname.
+ *
+ * Note also that we allow the user to provide a "hostname transformer" callback; this length restriction should be enforced _after_
+ * executing that callback.
+ *
+ * When starting a new workflow execution, we give Step Functions a user-specified workflow ID.
+ *
+ * Partition IDs are user-specified arbitrary strings. They are stored in the input data for a partitioned step.
+ * The input data has a maximum size of 256KB, but it will contain data other than just the partition IDs. To keep the size of the
+ * input data down, we will enforce a maximum size of 256 bytes for the partition IDs, but in practice most users will remain
+ * far below that.
+ *
+ * While it is tempting to impose a smaller limit than that in order to discourage people from using excessively long
+ * identifiers, we need to concern ourselves here only with values that Step Functions will reject or that will interfere with Flux.
+ *
+ * In summary, we will enforce these length limits:
+ * * Workflow class implementation name: 39
+ * * WorkflowStep class implementation name: 39
+ * * Hostname: 77
+ * * Workflow execution ID: 80
+ * * Partition ID: 256
+ *
+ * These fields will also validate the content of the string against SWF's list of allowed characters:
+ * * Workflow class implementation name
+ * * WorkflowStep class implementation name
+ * * Workflow execution ID
+ *
+ * These fields allow any content within the prescribed length:
+ * * Hostname
+ * * Partition ID
+ */
+public final class IdentifierValidation {
+
+    static final int MAX_WORKFLOW_CLASS_NAME_LENGTH = 39;
+    static final int MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH = 39;
+    static final int MAX_HOSTNAME_LENGTH = 77;
+    static final int MAX_WORKFLOW_EXECUTION_ID_LENGTH = 80;
+    static final int MAX_PARTITION_ID_LENGTH = 256;
+
+    private static final Pattern INVALID_CHARACTERS
+            = Pattern.compile("[\u0000-\u001F\u007F-\u009F \n\t<>{}\\[\\]?*\"#%\\\\^|~`$&,;:/]+");
+
+    private IdentifierValidation() {}
+
+    public static void validateWorkflowName(Class<? extends Workflow> clazz) {
+        validate("Workflow class names", TaskNaming.workflowName(clazz), MAX_WORKFLOW_CLASS_NAME_LENGTH, true);
+    }
+
+    public static void validateStepName(Class<? extends WorkflowStep> clazz) {
+        validate("WorkflowStep class names", TaskNaming.stepName(clazz), MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH, true);
+    }
+
+    public static void validateHostname(String hostname) {
+        validate("Hostnames", hostname, MAX_HOSTNAME_LENGTH, false);
+    }
+
+    public static void validateWorkflowExecutionId(String executionId) {
+        validate("Workflow Execution IDs", executionId, MAX_WORKFLOW_EXECUTION_ID_LENGTH, true);
+    }
+
+    public static void validatePartitionId(String partitionId) {
+        validate("Partition IDs", partitionId, MAX_PARTITION_ID_LENGTH, false);
+    }
+
+    /**
+     * For all the fields that limit input characters, Step Functions provides this description:
+     *
+     * A name must not contain:
+     *     white space
+     *     brackets < > { } [ ]
+     *     wildcard characters ? *
+     *     special characters " # % \ ^ | ~ ` $ & , ; : /
+     *     control characters (U+0000-001F, U+007F-009F)
+     * To enable logging with CloudWatch Logs, the name should only contain 0-9, A-Z, a-z, - and _.
+     *
+     * Flux won't enforce that the user's naming be CloudWatch Logs compatible, but Flux's naming won't prevent it either.
+     *
+     * Package-private for testing.
+     */
+    static void validate(String description, String inputToValidate, int max, boolean enforceCharacterConstraints) {
+        if (inputToValidate == null || inputToValidate.isEmpty()) {
+            throw new IllegalArgumentException(description + " must contain at least one character.");
+        }
+        if (inputToValidate.length() > max) {
+            throw new IllegalArgumentException(description + " must not be longer than " + max + " characters.");
+        }
+        if (enforceCharacterConstraints && INVALID_CHARACTERS.matcher(inputToValidate).find()) {
+            throw new IllegalArgumentException(description + " must not contain not contain whitespace, a comma,"
+                    + " any of <, >, {, }, [, ], ?, *, \", #, %, \\, ^, |, ~, `, $, &, ;, :, /,"
+                    + " or any control characters (\\u0000-\\u001f | \\u007f-\\u009f).");
+        }
+    }
+}

--- a/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/IdentifierValidationTest.java
+++ b/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/IdentifierValidationTest.java
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-package com.danielgmyers.flux.clients.swf;
+package com.danielgmyers.flux.clients.sfn;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
@@ -39,50 +39,26 @@ public class IdentifierValidationTest {
         for (char c = '\u007f'; c <= '\u009f'; c++) {
             sb.append(c);
         }
-        sb.append(':');
-        sb.append('/');
-        sb.append('|');
+        sb.append(" \t\n");
+        sb.append("<>{}[]");
+        sb.append("?*");
+        sb.append("\"#%\\^|~`$&,;:/");
         invalidCharacters = sb.toString();
-    }
-
-    @Test
-    public void testDomain() {
-        doCommonTests(IdentifierValidation::validateDomain, IdentifierValidation.MAX_DOMAIN_NAME_LENGTH, false);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> IdentifierValidation.validateDomain("arn"));
-    }
-
-    @Test
-    public void testTaskListName() {
-        doCommonTests(IdentifierValidation::validateTaskListName, IdentifierValidation.MAX_TASK_LIST_NAME_LENGTH, false);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> IdentifierValidation.validateTaskListName("arn"));
     }
 
     @Test
     public void testWorkflowExecutionId() {
         doCommonTests(IdentifierValidation::validateWorkflowExecutionId, IdentifierValidation.MAX_WORKFLOW_EXECUTION_ID_LENGTH, false);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> IdentifierValidation.validateWorkflowExecutionId("arn"));
     }
 
     @Test
     public void testHostname() {
         doCommonTests(IdentifierValidation::validateHostname, IdentifierValidation.MAX_HOSTNAME_LENGTH, true);
-        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateHostname("arn"));
-    }
-
-    @Test
-    public void testWorkflowExecutionTag() {
-        doCommonTests(IdentifierValidation::validateWorkflowExecutionTag, IdentifierValidation.MAX_WORKFLOW_EXECUTION_TAG_LENGTH, true);
-        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateWorkflowExecutionTag("arn"));
     }
 
     @Test
     public void testPartitionId() {
-        doCommonTests((s) -> IdentifierValidation.validatePartitionId(s, true), IdentifierValidation.MAX_PARTITION_ID_LENGTH_HASHING_ENABLED, true);
-        doCommonTests((s) -> IdentifierValidation.validatePartitionId(s, false), IdentifierValidation.MAX_PARTITION_ID_LENGTH_HASHING_DISABLED, false);
-
-        // "arn" should be allowed either way, even though invalid characters aren't allowed with hashing disabled.
-        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validatePartitionId("arn", true));
-        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validatePartitionId("arn", false));
+        doCommonTests(IdentifierValidation::validatePartitionId, IdentifierValidation.MAX_PARTITION_ID_LENGTH, true);
     }
 
     public static class TestWorkflowWithValidClassName implements Workflow {
@@ -93,7 +69,7 @@ public class IdentifierValidationTest {
         }
     }
 
-    public static class TestWorkflowWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInRealCodeNoMatterHowWideYourMonitorIs implements Workflow {
+    public static class TestWorkflowWithLongestAllowedClassName implements Workflow {
         // implementation doesn't need to be valid for this test
         @Override
         public WorkflowGraph getGraph() {
@@ -112,11 +88,11 @@ public class IdentifierValidationTest {
     @Test
     public void testWorkflowClassName() {
         // these two checks just ensure the test will break if the max name length constant or the class names get changed.
-        Assertions.assertEquals(IdentifierValidation.MAX_WORKFLOW_CLASS_NAME_LENGTH, TestWorkflowWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInRealCodeNoMatterHowWideYourMonitorIs.class.getSimpleName().length());
+        Assertions.assertEquals(IdentifierValidation.MAX_WORKFLOW_CLASS_NAME_LENGTH, TestWorkflowWithLongestAllowedClassName.class.getSimpleName().length());
         Assertions.assertTrue(IdentifierValidation.MAX_WORKFLOW_CLASS_NAME_LENGTH < TestWorkflowWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class.getSimpleName().length());
 
         Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateWorkflowName(TestWorkflowWithValidClassName.class));
-        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateWorkflowName(TestWorkflowWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInRealCodeNoMatterHowWideYourMonitorIs.class));
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateWorkflowName(TestWorkflowWithLongestAllowedClassName.class));
         Assertions.assertThrows(IllegalArgumentException.class,
                                 () -> IdentifierValidation.validateWorkflowName(TestWorkflowWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class));
     }
@@ -125,7 +101,7 @@ public class IdentifierValidationTest {
         // implementation doesn't need to be valid for this test
     }
 
-    public static class TestWorkflowStepWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInCodeNoMatterHowWideYourMonitorIs implements WorkflowStep {
+    public static class WorkflowStepWithLongestAllowedClassName implements WorkflowStep {
         // implementation doesn't need to be valid for this test
     }
 
@@ -136,11 +112,11 @@ public class IdentifierValidationTest {
     @Test
     public void testWorkflowStepClassName() {
         // these two checks just ensure the test will break if the max name length constant or the class names get changed.
-        Assertions.assertEquals(IdentifierValidation.MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH, TestWorkflowStepWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInCodeNoMatterHowWideYourMonitorIs.class.getSimpleName().length());
+        Assertions.assertEquals(IdentifierValidation.MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH, WorkflowStepWithLongestAllowedClassName.class.getSimpleName().length());
         Assertions.assertTrue(IdentifierValidation.MAX_WORKFLOW_STEP_CLASS_NAME_LENGTH < TestWorkflowStepWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class.getSimpleName().length());
 
         Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateStepName(TestWorkflowStepWithValidClassName.class));
-        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateStepName(TestWorkflowStepWithTechnicallyValidClassNameEvenThoughThisClassNameIsWayTooLongToBePracticalInCodeNoMatterHowWideYourMonitorIs.class));
+        Assertions.assertDoesNotThrow(() -> IdentifierValidation.validateStepName(WorkflowStepWithLongestAllowedClassName.class));
         Assertions.assertThrows(IllegalArgumentException.class,
                                 () -> IdentifierValidation.validateStepName(TestWorkflowStepWithOverlyLongClassNameThisClassNameIsMuchTooLongAndShouldNeverBeAllowedByTheValidationLogicEvenIfAskedExtremelyNicely.class));
     }
@@ -150,7 +126,7 @@ public class IdentifierValidationTest {
         for (int i = 0; i < invalidCharacters.length(); i++) {
             String id = invalidCharacters.substring(i, i+1);
             Assertions.assertThrows(IllegalArgumentException.class,
-                                    () -> IdentifierValidation.validate("test", id, 256, true, true), "failed on index " + i);
+                                    () -> IdentifierValidation.validate("test", id, 256, true), "failed on index " + i);
         }
     }
 
@@ -158,7 +134,7 @@ public class IdentifierValidationTest {
     public void testInternalValidate_AllowsEachInvalidCharacterIfFlagDisabled() {
         for (int i = 0; i < invalidCharacters.length(); i++) {
             String id = invalidCharacters.substring(i, i+1);
-            Assertions.assertDoesNotThrow(() -> IdentifierValidation.validate("test", id, 256, false, false), "failed on index " + i);
+            Assertions.assertDoesNotThrow(() -> IdentifierValidation.validate("test", id, 256, false), "failed on index " + i);
         }
     }
 
@@ -191,9 +167,8 @@ public class IdentifierValidationTest {
 
         StringBuilder result = new StringBuilder();
         for (int i = 0; i < length; i++) {
-            // if we're supposed to include invalid characters, we'll grab one from this list:
-            // \u0000-\u001f\u007f-\u009f:/|
-            // ... for every other character, starting with the first.
+            // if we're supposed to include invalid characters, we'll grab a random one from the invalidCharacters variable
+            // for every other character.
             if (includeInvalidCharacters && i % 2 == 0) {
                 int p = ThreadLocalRandom.current().nextInt(invalidCharacters.length());
                 result.append(invalidCharacters.charAt(p));

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/IdentifierValidation.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/IdentifierValidation.java
@@ -31,7 +31,7 @@ import com.danielgmyers.flux.wf.Workflow;
  * 3) ActivityTypes, which we generate by appending the WorkflowStep class names to their corresponding Workflow class names,
  *    separated by a period. (This way, if a step is reused across workflows, it gets a different ActivityType for each workflow.)
  *
- * When polling for work, we use the current host's hostname as part of the poller's identity, along with an Flux-specified
+ * When polling for work, we use the current host's hostname as part of the poller's identity, along with a Flux-specified
  * poller type, a small integer (between 0 and the thread pool size), and the user-specified task list being polled.
  *
  * When polling for work and when starting a new workflow execution, we give SWF a user-specified task list name.


### PR DESCRIPTION
The information about valid lengths and characters was taken from the Step Functions documentation e.g. https://docs.aws.amazon.com/step-functions/latest/apireference/API_CreateStateMachine.html

I also noticed the flux-swf unit test for workflow step name validation for maximum length was using the workflow class instead of the workflow step class. Doesn't matter functionally but I fixed it anyway.

https://github.com/danielgmyers/flux-swf-client/issues/120