### PR TITLE
[flux-sfn] Implement SfnWorkflowInfo and WorkflowStatusCheckerImpl.

### DIFF
--- a/flux-common-aws/pom.xml
+++ b/flux-common-aws/pom.xml
@@ -28,6 +28,12 @@
 
     <dependencies>
         <dependency>
+            <artifactId>arns</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awssdk.version}</version>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
             <artifactId>sdk-core</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awssdk.version}</version>

--- a/flux-common-aws/src/main/java/com/danielgmyers/flux/util/ArnUtils.java
+++ b/flux-common-aws/src/main/java/com/danielgmyers/flux/util/ArnUtils.java
@@ -1,0 +1,61 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.arns.Arn;
+
+/**
+ * In AWS, ARNs look like one of these:
+ *
+ * <pre>
+ * {@code
+ *  arn:<partition>:<service>:<region>:<account>:<resourcetype>/resource
+ *  arn:<partition>:<service>:<region>:<account>:<resourcetype>/resource/qualifier
+ *  arn:<partition>:<service>:<region>:<account>:<resourcetype>/resource:qualifier
+ *  arn:<partition>:<service>:<region>:<account>:<resourcetype>:resource
+ *  arn:<partition>:<service>:<region>:<account>:<resourcetype>:resource:qualifier
+ * }
+ * </pre>
+ *
+ * The AWS SDK provides an Arn class for parsing these values.
+ *
+ * This class provides helpers for extracting specific parts of ARNs, without needing to duplicate validation logic everywhere.
+ */
+public final class ArnUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(ArnUtils.class);
+
+    private ArnUtils() {}
+
+    /**
+     * Returns the qualifier portion of the provided ARN, if present.
+     * If not present, or the input is invalid, returns null.
+     */
+    public static String extractQualifier(String arn) {
+        try {
+            Arn parsed = Arn.fromString(arn);
+            return parsed.resource().qualifier().orElse(null);
+        } catch (IllegalArgumentException e) {
+            log.warn("The provided arn was invalid: {}", arn, e);
+            return null;
+        }
+    }
+
+}

--- a/flux-common-aws/src/test/java/com/danielgmyers/flux/util/ArnUtilsTest.java
+++ b/flux-common-aws/src/test/java/com/danielgmyers/flux/util/ArnUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ArnUtilsTest {
+
+    @Test
+    public void testExtractQualifier_ValidArnWithQualifier() {
+        Assertions.assertEquals("myworkflow", ArnUtils.extractQualifier("arn:aws:states:us-west-2:123456789012:execution:TestWorkflow:myworkflow"));
+    }
+
+    @Test
+    public void testExtractQualifier_ValidArnWithoutQualifier() {
+        Assertions.assertNull(ArnUtils.extractQualifier("arn:aws:states:us-west-2:123456789012:stateMachine:TestWorkflow"));
+    }
+
+    @Test
+    public void testExtractQualifier_InvalidArn() {
+        Assertions.assertNull(ArnUtils.extractQualifier("this:is:not:an:arn"));
+    }
+}

--- a/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/WorkflowStatusCheckerTest.java
+++ b/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/WorkflowStatusCheckerTest.java
@@ -1,0 +1,168 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn;
+
+import java.time.Instant;
+
+import com.danielgmyers.flux.WorkflowStatusChecker;
+import com.danielgmyers.flux.testutil.ManualClock;
+import com.danielgmyers.flux.wf.WorkflowInfo;
+import com.danielgmyers.flux.wf.WorkflowStatus;
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.sfn.SfnClient;
+import software.amazon.awssdk.services.sfn.model.DescribeExecutionRequest;
+import software.amazon.awssdk.services.sfn.model.DescribeExecutionResponse;
+import software.amazon.awssdk.services.sfn.model.ExecutionDoesNotExistException;
+import software.amazon.awssdk.services.sfn.model.ExecutionStatus;
+
+public class WorkflowStatusCheckerTest {
+
+    private ManualClock clock;
+
+    private static final String MACHINE_ARN = "arn:aws:states:us-west-2:123456789012:stateMachine:TestWorkflow";
+    private static final String EXECUTION_ID = "abcdefg";
+    private static final String EXECUTION_ARN = "arn:aws:states:us-west-2:123456789012:execution:TestWorkflow:" + EXECUTION_ID;
+
+    private IMocksControl mockery;
+    private SfnClient sfn;
+    private WorkflowStatusChecker wsc;
+
+    @BeforeEach
+    public void setup() {
+        clock = new ManualClock(Instant.now());
+        mockery = EasyMock.createControl();
+        sfn = mockery.createMock(SfnClient.class);
+        wsc = new WorkflowStatusCheckerImpl(clock, sfn, EXECUTION_ARN);
+    }
+
+    @Test
+    public void testWorkflowInfoValidWhenUnableToReachSfn() {
+        EasyMock.expect(sfn.describeExecution(buildDescribeRequest())).andThrow(ExecutionDoesNotExistException.builder().build()).times(2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.UNKNOWN, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.UNKNOWN);
+
+        mockery.verify();
+    }
+
+    @Test
+    public void testWorkflowUnknownWhenWorkflowExecutionNotFound() {
+        EasyMock.expect(sfn.describeExecution(buildDescribeRequest())).andThrow(ExecutionDoesNotExistException.builder().build()).times(2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.UNKNOWN, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.UNKNOWN);
+
+        mockery.verify();
+    }
+
+    @Test
+    public void testWorkflowInProgress() {
+        expectDescribeStatus(ExecutionStatus.RUNNING, 2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.IN_PROGRESS, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.IN_PROGRESS);
+
+        mockery.verify();
+    }
+
+    @Test
+    public void testWorkflowPendingRedrive() {
+        expectDescribeStatus(ExecutionStatus.PENDING_REDRIVE, 2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.IN_PROGRESS, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.IN_PROGRESS);
+
+        mockery.verify();
+    }
+
+    @Test
+    public void testWorkflowCompleted() {
+        expectDescribeStatus(ExecutionStatus.SUCCEEDED, 2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.COMPLETED, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.COMPLETED);
+
+        mockery.verify();
+    }
+
+    @Test
+    public void testWorkflowFailed() {
+        expectDescribeStatus(ExecutionStatus.FAILED, 2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.FAILED, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.FAILED);
+
+        mockery.verify();
+    }
+
+    @Test
+    public void testWorkflowTimedOut() {
+        expectDescribeStatus(ExecutionStatus.TIMED_OUT, 2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.TIMED_OUT, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.TIMED_OUT);
+
+        mockery.verify();
+    }
+
+    @Test
+    public void testWorkflowTerminated() {
+        expectDescribeStatus(ExecutionStatus.ABORTED, 2);
+        mockery.replay();
+
+        Assertions.assertEquals(WorkflowStatus.TERMINATED, wsc.checkStatus());
+        validateWorkflowInfo(wsc.getWorkflowInfo(), WorkflowStatus.TERMINATED);
+
+        mockery.verify();
+    }
+
+    private DescribeExecutionRequest buildDescribeRequest() {
+        return DescribeExecutionRequest.builder()
+                .executionArn(EXECUTION_ARN)
+                .build();
+    }
+
+    private void expectDescribeStatus(ExecutionStatus executionStatus, int times) {
+         DescribeExecutionResponse response = DescribeExecutionResponse.builder()
+                 .executionArn(EXECUTION_ARN)
+                 .stateMachineArn(MACHINE_ARN)
+                 .name(EXECUTION_ID)
+                 .status(executionStatus)
+                 .build();
+
+        EasyMock.expect(sfn.describeExecution(buildDescribeRequest())).andReturn(response).times(times);
+    }
+
+    private void validateWorkflowInfo(WorkflowInfo workflowInfo, WorkflowStatus expectedStatus) {
+        Assertions.assertEquals(expectedStatus, workflowInfo.getWorkflowStatus());
+        Assertions.assertEquals(clock.instant(), workflowInfo.getSnapshotTime());
+        Assertions.assertEquals(EXECUTION_ID, workflowInfo.getWorkflowId());
+        Assertions.assertEquals(EXECUTION_ARN, workflowInfo.getExecutionId());
+    }
+}


### PR DESCRIPTION
The main difference between this impl and the SWF impl (other than which service API it calls) is that this one returns a valid WorkflowInfo object with status UNKNOWN if it fails to retrieve the workflow status from the API, instead of returning null. I filed https://github.com/danielgmyers/flux-swf-client/issues/158 to update flux-swf to do the same thing.

https://github.com/danielgmyers/flux-swf-client/issues/120