### PR TITLE
[flux-sfn] Implement SfnStepInputAccessor and ActivityExecutor.

### DIFF
--- a/flux-common/src/main/java/com/danielgmyers/flux/ex/AttributeTypeMismatchException.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/ex/AttributeTypeMismatchException.java
@@ -22,7 +22,11 @@ package com.danielgmyers.flux.ex;
  */
 public class AttributeTypeMismatchException extends FluxException {
     public AttributeTypeMismatchException(Class<?> requestedType, String attributeName, Class<?> actualType) {
+        this(requestedType, attributeName, actualType.getSimpleName());
+    }
+
+    public AttributeTypeMismatchException(Class<?> requestedType, String attributeName, String typeDescription) {
         super(String.format("Requested type %s for attribute %s, but found type %s.",
-                            requestedType.getSimpleName(), attributeName, actualType.getSimpleName()));
+                requestedType.getSimpleName(), attributeName, typeDescription));
     }
 }

--- a/flux-common/src/main/java/com/danielgmyers/flux/ex/UnsupportedAttributeTypeException.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/ex/UnsupportedAttributeTypeException.java
@@ -1,0 +1,27 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.ex;
+
+/**
+ * Indicates that an attribute was requested with an unsupported type.
+ */
+public class UnsupportedAttributeTypeException extends FluxException {
+    public UnsupportedAttributeTypeException(Class<?> requestedType, String attributeName) {
+        super(String.format("Requested type %s for attribute %s is not supported.",
+                requestedType.getSimpleName(), attributeName));
+    }
+}

--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/poller/ActivityExecutor.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/poller/ActivityExecutor.java
@@ -1,0 +1,124 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn.poller;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import com.danielgmyers.flux.clients.sfn.step.SfnStepInputAccessor;
+import com.danielgmyers.flux.ex.FluxException;
+import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.StepAttributes;
+import com.danielgmyers.flux.step.StepResult;
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.step.internal.ActivityExecutionUtil;
+import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.metrics.MetricRecorder;
+import com.danielgmyers.metrics.MetricRecorderFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.services.sfn.model.GetActivityTaskResponse;
+
+/**
+ * Executes the WorkflowStep associated with a specified ActivityTask.
+ */
+public class ActivityExecutor implements Runnable {
+
+    private static final Logger log = LoggerFactory.getLogger(ActivityExecutor.class);
+
+    // package-private for test visibility
+    static final String WORKFLOW_ID_METRIC_NAME = "WorkflowId";
+    static final String WORKFLOW_RUN_ID_METRIC_NAME = "RunId";
+    static final String RETRY_CAUSE_FIELD_NAME = "RetryCause";
+
+    private final String identity;
+    private final GetActivityTaskResponse task;
+    private final Workflow workflow;
+    private final WorkflowStep step;
+    private final MetricRecorder fluxMetrics;
+    private final MetricRecorderFactory metricsFactory;
+
+    private StepResult result;
+    private String output;
+
+    // package-private, only ActivityTaskPoller should be creating these
+    ActivityExecutor(String identity, GetActivityTaskResponse task, Workflow workflow, WorkflowStep step,
+                     MetricRecorder fluxMetrics, MetricRecorderFactory metricsFactory) {
+        this.identity = identity;
+        this.task = task;
+        this.workflow = workflow;
+        this.step = step;
+        this.fluxMetrics = fluxMetrics;
+        this.metricsFactory = metricsFactory;
+        this.result = null;
+        this.output = null;
+    }
+
+    public StepResult getResult() {
+        return result;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    @Override
+    public void run() {
+        String activityName = TaskNaming.activityName(workflow, step);
+        log.debug("Worker {} received activity task for activity {}.", identity, TaskNaming.activityName(workflow, step));
+
+        try (MetricRecorder stepMetrics = metricsFactory.newMetricRecorder(activityName)) {
+            SfnStepInputAccessor stepInput = new SfnStepInputAccessor(task.input());
+
+            // In practice these two fields aren't meaningfully different for Step Functions, but we'll provide them both
+            // since people might have code looking for either of them.
+            stepMetrics.addProperty(WORKFLOW_ID_METRIC_NAME, stepInput.getAttribute(String.class, StepAttributes.WORKFLOW_ID));
+            stepMetrics.addProperty(WORKFLOW_RUN_ID_METRIC_NAME,
+                                    stepInput.getAttribute(String.class, StepAttributes.WORKFLOW_EXECUTION_ID));
+
+            result = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, stepInput, fluxMetrics, stepMetrics);
+
+            if (result.getAction() == StepResult.ResultAction.RETRY) {
+                // If the retry was caused by an exception, record the stack trace of the exception in the output.
+                if (result.getCause() != null) {
+                    StringWriter sw = new StringWriter();
+                    result.getCause().printStackTrace(new PrintWriter(sw));
+                    stepInput.addAttribute(RETRY_CAUSE_FIELD_NAME, sw.toString());
+                }
+            } else {
+                stepInput.addAttributes(result.getAttributes());
+                stepInput.addAttribute(StepAttributes.RESULT_CODE, result.getResultCode());
+                if (result.getMessage() != null && !result.getMessage().isEmpty()) {
+                    stepInput.addAttribute(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
+                }
+            }
+
+            output = stepInput.toJson();
+        } catch (JsonProcessingException e) {
+            // we've suppressed java.lang.Thread's default behavior (print to stdout), so we want the error logged.
+            String message = "Unable to parse activity input or output as json";
+            log.error(message, e);
+            throw new FluxException(message, e);
+        } catch (RuntimeException e) {
+            // we've suppressed java.lang.Thread's default behavior (print to stdout), so we want the error logged.
+            log.error("Caught an exception while executing activity task", e);
+            throw e;
+        }
+    }
+}

--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/step/SfnStepInputAccessor.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/step/SfnStepInputAccessor.java
@@ -1,0 +1,158 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn.step;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.danielgmyers.flux.ex.AttributeTypeMismatchException;
+import com.danielgmyers.flux.ex.FluxException;
+import com.danielgmyers.flux.ex.UnsupportedAttributeTypeException;
+import com.danielgmyers.flux.step.StepInputAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+public class SfnStepInputAccessor implements StepInputAccessor {
+
+    // Map is supported too but we have to check it separately since we don't want to require a specific Map implementation.
+    static final Set<Class<?>> SUPPORTED_ATTRIBUTE_TYPES
+            = Set.of(Boolean.class, Long.class, String.class, Instant.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ObjectNode attributes;
+
+    // package-private for unit test access
+    ObjectNode getAttributesNode() {
+        return attributes;
+    }
+
+    public SfnStepInputAccessor(String rawInput) throws JsonProcessingException {
+        if (rawInput == null || rawInput.isEmpty()) {
+            attributes = MAPPER.createObjectNode();
+        } else {
+            JsonNode input = MAPPER.readTree(rawInput);
+            if (!input.isObject()) {
+                throw new FluxException("Expected step input to be a json map, but it was not: " + rawInput);
+            }
+            attributes = (ObjectNode) input;
+        }
+    }
+
+    /**
+     * Retrieves the requested attribute and validates that it's compatible with the stored value.
+     * Note that we store Instants as millis-since-epoch, as Longs.
+     * As such we can't really tell the difference between Long and Instant, so in practice
+     * they'll work interchangeably (whether the resulting value makes sense or not).
+     */
+    @Override
+    public <T> T getAttribute(Class<T> requestedType, String attributeName) {
+        if (!SUPPORTED_ATTRIBUTE_TYPES.contains(requestedType) && !Map.class.isAssignableFrom(requestedType)) {
+            throw new UnsupportedAttributeTypeException(requestedType, attributeName);
+        }
+
+        JsonNode attr = attributes.get(attributeName);
+        if (attr == null || attr.isNull()) {
+            return null;
+        }
+        if (requestedType == Boolean.class) {
+            return (T)validateAttr(requestedType, attributeName, attr, attr::isBoolean, attr::asBoolean);
+        }
+        if (requestedType == Long.class) {
+            return (T)validateAttr(requestedType, attributeName, attr, attr::canConvertToLong, attr::asLong);
+        }
+        if (requestedType == String.class) {
+            return (T)validateAttr(requestedType, attributeName, attr, attr::isTextual, attr::asText);
+        }
+        if (requestedType == Instant.class) {
+            Long epochMillis = validateAttr(Instant.class, attributeName, attr, attr::canConvertToLong, attr::asLong);
+            return (T)Instant.ofEpochMilli(epochMillis);
+        }
+
+        // Only support Map<String, String>, not other map types
+        if (Map.class.isAssignableFrom(requestedType)) {
+            Map<String, String> output = new HashMap<>();
+            Iterator<Map.Entry<String, JsonNode>> fields
+                    = validateAttr(Map.class, attributeName, attr, attr::isObject, attr::fields);
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                String subAttributeName = String.format("%s.%s", attributeName, field.getKey());
+                JsonNode subAttr = field.getValue();
+                String value = null;
+                if (!subAttr.isNull()) {
+                    value = validateAttr(String.class, subAttributeName, subAttr, subAttr::isTextual, subAttr::asText);
+                }
+                output.put(field.getKey(), value);
+            }
+            return (T)output;
+        }
+
+        throw new IllegalStateException("Missing implementation for a supported type " + requestedType.getSimpleName() + "!");
+    }
+
+    public void addAttribute(String attributeName, Object value) {
+        if (!SUPPORTED_ATTRIBUTE_TYPES.contains(value.getClass()) && !Map.class.isAssignableFrom(value.getClass())) {
+            throw new UnsupportedAttributeTypeException(value.getClass(), attributeName);
+        }
+
+        if (value.getClass() == Boolean.class) {
+            attributes.set(attributeName, BooleanNode.valueOf((boolean)value));
+        } else if (value.getClass() == Long.class) {
+            attributes.set(attributeName, LongNode.valueOf((long)value));
+        } else if (value.getClass() == String.class) {
+            attributes.set(attributeName, TextNode.valueOf((String)value));
+        } else if (value.getClass() == Instant.class) {
+            attributes.set(attributeName, LongNode.valueOf(((Instant)value).toEpochMilli()));
+        } else if (Map.class.isAssignableFrom(value.getClass())) {
+            ObjectNode child = MAPPER.createObjectNode();
+            for (Map.Entry<String, String> e : ((Map<String, String>)value).entrySet()) {
+                child.set(e.getKey(), TextNode.valueOf(e.getValue()));
+            }
+            attributes.set(attributeName, child);
+        } else {
+            throw new IllegalStateException("Missing implementation for a supported type "
+                                            + value.getClass().getSimpleName() + "!");
+        }
+    }
+
+    public void addAttributes(Map<String, Object> data) {
+        for (Map.Entry<String, Object> e : data.entrySet()) {
+            addAttribute(e.getKey(), e.getValue());
+        }
+    }
+
+    public String toJson() throws JsonProcessingException {
+        return MAPPER.writeValueAsString(attributes);
+    }
+
+    private <T> T validateAttr(Class<?> requestedType, String attributeName, JsonNode node,
+                               Supplier<Boolean> validator, Supplier<T> retriever) {
+        if (!validator.get()) {
+            throw new AttributeTypeMismatchException(requestedType, attributeName, node.getNodeType().toString());
+        }
+        return retriever.get();
+    }
+}

--- a/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/poller/ActivityExecutorTest.java
+++ b/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/poller/ActivityExecutorTest.java
@@ -1,0 +1,257 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn.poller;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.danielgmyers.flux.clients.sfn.step.SfnStepInputAccessor;
+import com.danielgmyers.flux.clients.sfn.util.SfnArnFormatter;
+import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.StepApply;
+import com.danielgmyers.flux.step.StepAttributes;
+import com.danielgmyers.flux.step.StepResult;
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.step.internal.ActivityExecutionUtil;
+import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.flux.wf.graph.WorkflowGraph;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphBuilder;
+import com.danielgmyers.metrics.recorders.InMemoryMetricRecorder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.sfn.model.GetActivityTaskResponse;
+
+public class ActivityExecutorTest {
+
+    private static final String IDENTITY = "unit";
+    private static final String TASK_TOKEN = "task-token";
+    private static final String WORKFLOW_NAME = "some-workflow-name";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private DummyStep step;
+    private InMemoryMetricRecorder fluxMetrics;
+    private InMemoryMetricRecorder stepMetrics;
+
+    @BeforeEach
+    public void setup() {
+        step = new DummyStep();
+        fluxMetrics = new InMemoryMetricRecorder("ActivityExecutor");
+        stepMetrics = new InMemoryMetricRecorder(TaskNaming.activityName(TestWorkflow.class, DummyStep.class));
+    }
+
+    @Test
+    public void returnsCompleteForSuccessCase_IncludesInputInFinalOutputJson() throws JsonProcessingException {
+        Map<String, Object> input = new HashMap<>();
+        input.put(StepAttributes.WORKFLOW_ID, WORKFLOW_NAME);
+        input.put(StepAttributes.WORKFLOW_EXECUTION_ID, SfnArnFormatter.executionArn("us-west-2", "123456789012", TestWorkflow.class, WORKFLOW_NAME));
+        input.put("starship", "enterprise");
+        input.put("registry", 1701L);
+
+        Map<String, Object> output = new HashMap<>();
+        output.put("captain", "kirk");
+
+        GetActivityTaskResponse task = makeTask(input);
+        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
+
+        StepResult result = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(result);
+
+        executor.run();
+        Assertions.assertTrue(step.didThing());
+
+        // fluxMetrics is usually closed by the ActivityTaskPoller.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Map<String, Object> expectedOutputContent = new HashMap<>();
+        expectedOutputContent.putAll(input);
+        expectedOutputContent.putAll(output);
+        expectedOutputContent.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
+        expectedOutputContent.put(StepAttributes.RESULT_CODE, result.getResultCode());
+
+        validateOutput(expectedOutputContent, executor.getOutput());
+
+        Assertions.assertNotNull(executor.getResult());
+        Assertions.assertEquals(result, executor.getResult());
+
+        Assertions.assertTrue(fluxMetrics.isClosed());
+        Assertions.assertTrue(stepMetrics.isClosed());
+
+        Assertions.assertEquals(input.get(StepAttributes.WORKFLOW_ID), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
+        Assertions.assertEquals(input.get(StepAttributes.WORKFLOW_EXECUTION_ID), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
+
+        String activityName = TaskNaming.activityName(TestWorkflow.class, DummyStep.class);
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(activityName,
+                                result.getResultCode())).intValue());
+    }
+
+    @Test
+    public void returnsRetryWhenApplyReturnsRetry() throws JsonProcessingException {
+        Map<String, Object> input = new HashMap<>();
+        input.put(StepAttributes.WORKFLOW_ID, WORKFLOW_NAME);
+        input.put(StepAttributes.WORKFLOW_EXECUTION_ID, SfnArnFormatter.executionArn("us-west-2", "123456789012", TestWorkflow.class, WORKFLOW_NAME));
+
+        GetActivityTaskResponse task = makeTask(input);
+        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
+
+        StepResult result = makeStepResult(StepResult.ResultAction.RETRY, null, "hmm", Collections.emptyMap());
+        step.setStepResult(result);
+
+        executor.run();
+        Assertions.assertTrue(step.didThing()); // true because the step did a thing before specifically deciding to return retry
+
+        // fluxMetrics is usually closed by the ActivityTaskPoller.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        Map<String, Object> expectedOutputContent = new HashMap<>();
+
+        validateOutput(expectedOutputContent, executor.getOutput());
+
+        Assertions.assertNotNull(executor.getResult());
+        Assertions.assertEquals(result, executor.getResult());
+
+        Assertions.assertTrue(fluxMetrics.isClosed());
+        Assertions.assertTrue(stepMetrics.isClosed());
+
+        Assertions.assertEquals(input.get(StepAttributes.WORKFLOW_ID), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
+        Assertions.assertEquals(input.get(StepAttributes.WORKFLOW_EXECUTION_ID), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
+
+        String activityName = TaskNaming.activityName(TestWorkflow.class, DummyStep.class);
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatRetryResultMetricName(activityName,
+                                null)).intValue());
+    }
+
+    @Test
+    public void returnsRetryWhenApplyThrowsException() throws JsonProcessingException {
+        Map<String, Object> input = new HashMap<>();
+        input.put(StepAttributes.WORKFLOW_ID, WORKFLOW_NAME);
+        input.put(StepAttributes.WORKFLOW_EXECUTION_ID, SfnArnFormatter.executionArn("us-west-2", "123456789012", TestWorkflow.class, WORKFLOW_NAME));
+
+        GetActivityTaskResponse task = makeTask(input);
+        ActivityExecutor executor = new ActivityExecutor(IDENTITY, task, new TestWorkflow(), step, fluxMetrics,  (o, c) -> stepMetrics);
+
+        RuntimeException e = new RuntimeException("message!");
+        step.setExceptionToThrow(e);
+
+        executor.run();
+        Assertions.assertFalse(step.didThing()); // false because the step threw an exception in the middle of doing the thing
+
+        // fluxMetrics is usually closed by the ActivityTaskPoller.
+        // We need to close it so we can query its data.
+        fluxMetrics.close();
+
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        String stackTrace = sw.toString();
+
+        Map<String, Object> expectedOutputContent = new HashMap<>();
+        expectedOutputContent.put(ActivityExecutor.RETRY_CAUSE_FIELD_NAME, stackTrace);
+
+        validateOutput(expectedOutputContent, executor.getOutput());
+
+        Assertions.assertNotNull(executor.getResult());
+        Assertions.assertEquals(StepResult.ResultAction.RETRY, executor.getResult().getAction());
+
+        Assertions.assertTrue(fluxMetrics.isClosed());
+        Assertions.assertTrue(stepMetrics.isClosed());
+
+        Assertions.assertEquals(input.get(StepAttributes.WORKFLOW_ID), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_ID_METRIC_NAME));
+        Assertions.assertEquals(input.get(StepAttributes.WORKFLOW_EXECUTION_ID), stepMetrics.getProperties().get(ActivityExecutor.WORKFLOW_RUN_ID_METRIC_NAME));
+
+        String activityName = TaskNaming.activityName(TestWorkflow.class, DummyStep.class);
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatRetryResultMetricName(activityName,
+                                e.getClass().getSimpleName())).intValue());
+    }
+
+    private GetActivityTaskResponse makeTask(Map<String, Object> input) throws JsonProcessingException {
+        return GetActivityTaskResponse.builder()
+                .taskToken(TASK_TOKEN)
+                .input(MAPPER.writeValueAsString(input))
+                .build();
+    }
+
+    private StepResult makeStepResult(StepResult.ResultAction resultAction, String stepResult, String message, Map<String, Object> output) {
+        return new StepResult(resultAction, stepResult, message).withAttributes(output);
+    }
+
+    private void validateOutput(Map<String, Object> expectedOutputFields, String actualOutput) throws JsonProcessingException {
+        SfnStepInputAccessor outputAccessor = new SfnStepInputAccessor(actualOutput);
+
+        for (Map.Entry<String, Object> f : expectedOutputFields.entrySet()) {
+            Assertions.assertEquals(f.getValue(), outputAccessor.getAttribute(f.getValue().getClass(), f.getKey()));
+        }
+    }
+
+    public class TestWorkflow implements Workflow {
+
+        private final WorkflowGraph graph;
+
+        public TestWorkflow() {
+            WorkflowGraphBuilder graph = new WorkflowGraphBuilder(step);
+            graph.alwaysClose(step);
+            this.graph = graph.build();
+        }
+
+        @Override
+        public WorkflowGraph getGraph() {
+            return graph;
+        }
+    }
+
+    public static class DummyStep implements WorkflowStep {
+
+        private boolean didThing = false;
+        private RuntimeException exceptionToThrow = null;
+        private StepResult result = null;
+        private long sleepDurationMillis = 0;
+
+        public void setExceptionToThrow(RuntimeException e) {
+            this.exceptionToThrow = e;
+        }
+
+        public void setStepResult(StepResult result) {
+            this.result = result;
+        }
+
+        @StepApply
+        public StepResult doThing() throws InterruptedException {
+            if(exceptionToThrow != null) {
+                throw exceptionToThrow;
+            }
+
+            if(sleepDurationMillis > 0) {
+                Thread.sleep(sleepDurationMillis);
+            }
+
+            didThing = true;
+            return result;
+        }
+
+        public boolean didThing() {
+            return didThing;
+        }
+    }
+}

--- a/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/step/SfnStepInputAccessorTest.java
+++ b/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/step/SfnStepInputAccessorTest.java
@@ -1,0 +1,254 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn.step;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import com.danielgmyers.flux.ex.AttributeTypeMismatchException;
+import com.danielgmyers.flux.ex.FluxException;
+import com.danielgmyers.flux.ex.UnsupportedAttributeTypeException;
+import com.danielgmyers.flux.step.StepInputAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SfnStepInputAccessorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void testInputIsNotJsonObjectMap() throws JsonProcessingException {
+        Assertions.assertThrows(FluxException.class, () -> new SfnStepInputAccessor("1"));
+        Assertions.assertThrows(FluxException.class, () -> new SfnStepInputAccessor("[1,2,3,4]"));
+        Assertions.assertThrows(FluxException.class, () -> new SfnStepInputAccessor("true"));
+    }
+
+    @Test
+    public void testNullOrEmptyInputOrEmptyMap() throws JsonProcessingException {
+        SfnStepInputAccessor accessor = new SfnStepInputAccessor(null);
+        Assertions.assertTrue(accessor.getAttributesNode().isEmpty());
+
+        accessor = new SfnStepInputAccessor("");
+        Assertions.assertTrue(accessor.getAttributesNode().isEmpty());
+
+        accessor = new SfnStepInputAccessor("{}");
+        Assertions.assertTrue(accessor.getAttributesNode().isEmpty());
+    }
+
+    @Test
+    public void testNullAndMissingValues() throws JsonProcessingException {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("entry", null);
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        for (Class<?> supportedType : SfnStepInputAccessor.SUPPORTED_ATTRIBUTE_TYPES) {
+            Assertions.assertNull(accessor.getAttribute(supportedType, "entry"));
+            Assertions.assertNull(accessor.getAttribute(supportedType, "missing_key"));
+        }
+    }
+
+    @Test
+    public void testLongAndInstantValue() throws JsonProcessingException {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("long", 42L);
+        attributes.put("timestamp", Instant.now().toEpochMilli());
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        for (String key : attributes.keySet()) {
+            long value = (long)(attributes.get(key));
+            for (Class<?> supportedType : SfnStepInputAccessor.SUPPORTED_ATTRIBUTE_TYPES) {
+                if (supportedType == Long.class) {
+                    Assertions.assertEquals(value, accessor.getAttribute(supportedType, key));
+                } else if (supportedType == Instant.class) {
+                    Assertions.assertEquals(Instant.ofEpochMilli(value), accessor.getAttribute(supportedType, key));
+                } else {
+                    Assertions.assertThrows(AttributeTypeMismatchException.class,
+                            () -> accessor.getAttribute(supportedType, key));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testStringValue() throws JsonProcessingException {
+        String value = "asdfghjkl";
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("entry", value);
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        for (Class<?> supportedType : SfnStepInputAccessor.SUPPORTED_ATTRIBUTE_TYPES) {
+            if (supportedType == String.class) {
+                Assertions.assertEquals(value, accessor.getAttribute(supportedType, "entry"));
+            } else {
+                Assertions.assertThrows(AttributeTypeMismatchException.class,
+                        () -> accessor.getAttribute(supportedType, "entry"));
+            }
+        }
+    }
+
+    @Test
+    public void testBooleanValues() throws JsonProcessingException {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("entry1", true);
+        attributes.put("entry2", false);
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        for (String key : attributes.keySet()) {
+            boolean value = (boolean)(attributes.get(key));
+            for (Class<?> supportedType : SfnStepInputAccessor.SUPPORTED_ATTRIBUTE_TYPES) {
+                if (supportedType == Boolean.class) {
+                    Assertions.assertEquals(value, accessor.getAttribute(supportedType, key));
+                } else {
+                    Assertions.assertThrows(AttributeTypeMismatchException.class,
+                            () -> accessor.getAttribute(supportedType, key));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testStringMapValue() throws JsonProcessingException {
+        Map<String, String> subMap = new HashMap<>();
+        subMap.put("a", "b");
+        subMap.put("c", null);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("entry", subMap);
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        for (Class<?> supportedType : SfnStepInputAccessor.SUPPORTED_ATTRIBUTE_TYPES) {
+            if (supportedType == Map.class) {
+                Assertions.assertEquals(subMap, accessor.getAttribute(supportedType, "entry"));
+            } else {
+                Assertions.assertThrows(AttributeTypeMismatchException.class,
+                        () -> accessor.getAttribute(supportedType, "entry"));
+            }
+        }
+    }
+
+    @Test
+    public void testStringMapValue_subMapCannotContainLong() throws JsonProcessingException {
+        Map<String, Object> subMap = new HashMap<>();
+        subMap.put("a", 42L);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("entry", subMap);
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        Assertions.assertThrows(AttributeTypeMismatchException.class,
+                () -> accessor.getAttribute(Map.class, "entry"));
+    }
+
+    @Test
+    public void testStringMapValue_subMapCannotContainBoolean() throws JsonProcessingException {
+        Map<String, Object> subMap = new HashMap<>();
+        subMap.put("a", true);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("entry", subMap);
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        Assertions.assertThrows(AttributeTypeMismatchException.class,
+                () -> accessor.getAttribute(Map.class, "entry"));
+    }
+
+    @Test
+    public void testStringMapValue_subMapCannotContainMap() throws JsonProcessingException {
+        Map<String, Object> subMap = new HashMap<>();
+        subMap.put("a", new HashMap<>());
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("entry", subMap);
+
+        String encoded = MAPPER.writeValueAsString(attributes);
+
+        StepInputAccessor accessor = new SfnStepInputAccessor(encoded);
+        Assertions.assertThrows(AttributeTypeMismatchException.class,
+                () -> accessor.getAttribute(Map.class, "entry"));
+    }
+
+    @Test
+    public void testAddAttribute() throws JsonProcessingException {
+        SfnStepInputAccessor accessor = new SfnStepInputAccessor("{}");
+
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+        Map<String, String> stringmap = new HashMap<>();
+        stringmap.put("a", "b");
+        stringmap.put("c", "d");
+
+        Map<String, Object> additionalAttributes = new HashMap<>();
+        additionalAttributes.put("entry1", "value1");
+        additionalAttributes.put("entry2", "value2");
+
+        accessor.addAttribute("bool", true);
+        accessor.addAttribute("long", 42L);
+        accessor.addAttribute("string", "some value");
+        accessor.addAttribute("timestamp", now.toEpochMilli());
+        accessor.addAttribute("map", stringmap);
+        accessor.addAttributes(additionalAttributes);
+
+        Assertions.assertEquals(true, accessor.getAttribute(Boolean.class, "bool"));
+        Assertions.assertEquals(42L, accessor.getAttribute(Long.class, "long"));
+        Assertions.assertEquals("some value", accessor.getAttribute(String.class, "string"));
+        Assertions.assertEquals(now, accessor.getAttribute(Instant.class, "timestamp"));
+        Assertions.assertEquals(stringmap, accessor.getAttribute(Map.class, "map"));
+        Assertions.assertEquals("value1", accessor.getAttribute(String.class, "entry1"));
+        Assertions.assertEquals("value2", accessor.getAttribute(String.class, "entry2"));
+    }
+
+    @Test
+    public void testAddUnsupportedAttributeType() throws JsonProcessingException {
+        SfnStepInputAccessor accessor = new SfnStepInputAccessor("{}");
+
+        Assertions.assertThrows(UnsupportedAttributeTypeException.class,
+                                () -> accessor.addAttribute("bad", new Date()));
+        Assertions.assertThrows(UnsupportedAttributeTypeException.class,
+                                () -> accessor.addAttribute("bad", new ArrayList<String>()));
+        Assertions.assertThrows(UnsupportedAttributeTypeException.class,
+                                () -> accessor.addAttribute("bad", new HashSet<String>()));
+    }
+
+    @Test
+    public void toJson() throws JsonProcessingException {
+        SfnStepInputAccessor accessor = new SfnStepInputAccessor("{\"a\":\"b\"}");
+        accessor.addAttribute("c", "d");
+
+        Assertions.assertEquals("{\"a\":\"b\",\"c\":\"d\"}", accessor.toJson());
+    }
+}


### PR DESCRIPTION
SfnStepInputAccessor reads the input into a JsonNode tree and deserializes individual attributes on request.

ActivityExecutor includes the full set of input attributes in the output, because there's not a clean way to have Step Functions actually merge the input and output into the same object as part of the step definition.

Added UnsupportedAttributeTypeException for StepInputAccessors to throw as needed.

https://github.com/danielgmyers/flux-swf-client/issues/120
