### PR TITLE
[flux-sfn] Implement parts of FluxCapacitorImpl.

### DIFF
--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/FluxCapacitorConfig.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/FluxCapacitorConfig.java
@@ -16,6 +16,8 @@
 
 package com.danielgmyers.flux.clients.sfn;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -31,6 +33,7 @@ public class FluxCapacitorConfig {
     private Function<String, String> hostnameTransformerForPollerIdentity = (hostname) -> hostname;
     private String sfnEndpoint;
     private ClientOverrideConfiguration clientOverrideConfiguration;
+    private final Map<String, TaskListConfig> taskListConfigs = new HashMap<>();
     private Function<String, RemoteSfnClientConfig> remoteSfnClientConfigProvider;
 
     public String getAwsRegion() {
@@ -134,6 +137,26 @@ public class FluxCapacitorConfig {
      */
     public void setClientOverrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration) {
         this.clientOverrideConfiguration = clientOverrideConfiguration;
+    }
+
+    /**
+     * Stores the provided task list configuration for the specified task list name.
+     *
+     * Task lists that are not explicitly configured will get the default task list configuration;
+     * see TaskListConfig for more information on the default values.
+     */
+    public void putTaskListConfig(String taskListName, TaskListConfig config) {
+        if (taskListName == null) {
+            throw new IllegalArgumentException("taskListName may not be null.");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("config may not be null.");
+        }
+        this.taskListConfigs.put(taskListName, config);
+    }
+
+    public TaskListConfig getTaskListConfig(String taskList) {
+        return taskListConfigs.computeIfAbsent(taskList, name -> new TaskListConfig());
     }
 
     /**

--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/FluxCapacitorImpl.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/FluxCapacitorImpl.java
@@ -16,22 +16,41 @@
 
 package com.danielgmyers.flux.clients.sfn;
 
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.danielgmyers.flux.FluxCapacitor;
 import com.danielgmyers.flux.RemoteWorkflowExecutor;
 import com.danielgmyers.flux.WorkflowStatusChecker;
+import com.danielgmyers.flux.clients.sfn.poller.ActivityTaskPoller;
 import com.danielgmyers.flux.clients.sfn.util.SfnArnFormatter;
+import com.danielgmyers.flux.ex.FluxException;
+import com.danielgmyers.flux.poller.TaskNaming;
 import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.threads.BlockOnSubmissionThreadPoolExecutor;
+import com.danielgmyers.flux.threads.ThreadUtils;
+import com.danielgmyers.flux.util.AwsRetryUtils;
 import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphNode;
+import com.danielgmyers.metrics.MetricRecorder;
 import com.danielgmyers.metrics.MetricRecorderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +64,9 @@ import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sfn.SfnClient;
 import software.amazon.awssdk.services.sfn.SfnClientBuilder;
+import software.amazon.awssdk.services.sfn.model.ActivityListItem;
+import software.amazon.awssdk.services.sfn.model.CreateActivityRequest;
+import software.amazon.awssdk.services.sfn.model.ListActivitiesRequest;
 import software.amazon.awssdk.services.sfn.model.StartExecutionRequest;
 
 /**
@@ -54,13 +76,27 @@ public class FluxCapacitorImpl implements FluxCapacitor {
 
     private static final Logger log = LoggerFactory.getLogger(FluxCapacitorImpl.class);
 
+    private static final String LIST_ACTIVITIES_METRIC_PREFIX = "Flux.ListActivities";
+    private static final String CREATE_ACTIVITY_METRIC_PREFIX = "Flux.CreateActivity";
+
     private final SfnClient sfn;
     private final FluxCapacitorConfig config;
     private final MetricRecorderFactory metricsFactory;
     private final Clock clock;
 
     private final Map<Class<? extends Workflow>, Workflow> workflowsByClass;
-    private final Map<Class<? extends WorkflowStep>, WorkflowStep> activitiesByClass;
+    private final Map<String, WorkflowStep> activitiesByName;
+    private final Map<String, Workflow> workflowsByActivityName;
+
+    private Map<String, ScheduledExecutorService> activityTaskPollerThreadsPerActivity;
+    private Map<String, BlockOnSubmissionThreadPoolExecutor> workerThreadsPerTaskList;
+    private ScheduledExecutorService periodicWorkflowScheduler;
+
+    // The default throttling refill rate for the CreateActivity APIs is 1 per second,
+    // so there's no sense retrying more frequently than that by default.
+    private static final long REGISTRATION_MAX_RETRY_ATTEMPTS = 5;
+    private static final Duration REGISTRATION_MIN_RETRY_DELAY = Duration.ofSeconds(1);
+    private static final Duration REGISTRATION_MAX_RETRY_DELAY = Duration.ofSeconds(5);
 
     /**
      * Initializes a FluxCapacitor object. Package-private for unit test use.
@@ -75,7 +111,23 @@ public class FluxCapacitorImpl implements FluxCapacitor {
         this.clock = clock;
 
         this.workflowsByClass = new HashMap<>();
-        this.activitiesByClass = new HashMap<>();
+        this.activitiesByName = new HashMap<>();
+        this.workflowsByActivityName = new HashMap<>();
+    }
+
+    // package-private for test access.
+    Map<Class<? extends Workflow>, Workflow> getWorkflowsByClass() {
+        return workflowsByClass;
+    }
+
+    // package-private for test access.
+    Map<String, WorkflowStep> getActivitiesByName() {
+        return activitiesByName;
+    }
+
+    // package-private for test access.
+    Map<String, Workflow> getWorkflowsByActivityName() {
+        return workflowsByActivityName;
     }
 
     /**
@@ -123,7 +175,17 @@ public class FluxCapacitorImpl implements FluxCapacitor {
 
     @Override
     public void initialize(List<Workflow> workflows) {
+        if (workflows == null || workflows.isEmpty()) {
+            throw new IllegalArgumentException("The specified workflow list must not be empty.");
+        } else if (!workflowsByClass.isEmpty()) {
+            throw new IllegalArgumentException("Flux is already initialized.");
+        }
 
+        populateMaps(workflows);
+        registerActivities();
+        registerWorkflows();
+        initializePollers();
+        startPeriodicWorkflows();
     }
 
     @Override
@@ -149,6 +211,9 @@ public class FluxCapacitorImpl implements FluxCapacitor {
             throw new IllegalStateException("Cannot create a remote workflow executor without a remote client config provider.");
         }
         RemoteSfnClientConfig remoteConfig = remoteConfigProvider.apply(endpointId);
+        if (remoteConfig == null) {
+            throw new IllegalStateException("Cannot create a remote workflow executor without any remote client config.");
+        }
 
         AwsCredentialsProvider credentials = remoteConfig.getCredentials();
         if (credentials == null) {
@@ -171,12 +236,44 @@ public class FluxCapacitorImpl implements FluxCapacitor {
 
     @Override
     public void shutdown() {
-
+        for (ExecutorService s : activityTaskPollerThreadsPerActivity.values()) {
+            s.shutdown();
+        }
+        for (ExecutorService s : workerThreadsPerTaskList.values()) {
+            s.shutdown();
+        }
+        periodicWorkflowScheduler.shutdown();
     }
 
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return false;
+        long timeoutMillis = TimeUnit.MILLISECONDS.convert(timeout, unit);
+        timeoutMillis = awaitTerminationAndReturnRemainingMillis(timeoutMillis, activityTaskPollerThreadsPerActivity.values());
+        if (timeoutMillis < 0) {
+            return false;
+        }
+        timeoutMillis = awaitTerminationAndReturnRemainingMillis(timeoutMillis, workerThreadsPerTaskList.values());
+        if (timeoutMillis < 0) {
+            return false;
+        }
+        return periodicWorkflowScheduler.awaitTermination(timeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    private long awaitTerminationAndReturnRemainingMillis(long timeoutMillis,
+                                                          Collection<? extends ExecutorService> executors)
+            throws InterruptedException {
+        Duration remaining = Duration.ofMillis(timeoutMillis);
+        for (ExecutorService s : executors) {
+            if (remaining.isNegative()) {
+                return remaining.toMillis();
+            }
+            Instant start = Instant.now();
+            if (!s.awaitTermination(remaining.toMillis(), TimeUnit.MILLISECONDS)) {
+                return -1;
+            }
+            remaining = remaining.minus(Duration.between(start, Instant.now()));
+        }
+        return remaining.toMillis();
     }
 
     // Package-private for RemoteWorkflowExecutorImpl and unit test access
@@ -187,5 +284,168 @@ public class FluxCapacitorImpl implements FluxCapacitor {
                 .name(executionId)
                 .stateMachineArn(SfnArnFormatter.workflowArn(awsRegion, awsAccountId, workflow.getClass()))
                 .build();
+    }
+
+    // package-private for testing
+    void populateMaps(List<Workflow> workflows) {
+        Set<String> workflowNames = new HashSet<>();
+        for (Workflow workflow : workflows) {
+            IdentifierValidation.validateWorkflowName(workflow.getClass());
+
+            String workflowName = TaskNaming.workflowName(workflow.getClass());
+            if (workflowNames.contains(workflowName)) {
+                String message = "Received more than one Workflow object with the same class name: " + workflowName;
+                log.error(message);
+                throw new FluxException(message);
+            }
+            workflowNames.add(workflowName);
+            workflowsByClass.put(workflow.getClass(), workflow);
+
+            for (Map.Entry<Class<? extends WorkflowStep>, WorkflowGraphNode> entry : workflow.getGraph().getNodes().entrySet()) {
+                IdentifierValidation.validateStepName(entry.getKey());
+
+                String activityName = buildSfnActivityName(workflow.getClass(), entry.getValue().getStep().getClass());
+                if (activitiesByName.containsKey(activityName)) {
+                    String message = "Workflow " + workflowName + " has two steps with the same name: "
+                            + entry.getValue().getStep().getClass().getSimpleName();
+                    log.error(message);
+                    throw new FluxException(message);
+                }
+                activitiesByName.put(activityName, entry.getValue().getStep());
+                workflowsByActivityName.put(activityName, workflow);
+            }
+        }
+    }
+
+    // package-private for test access
+    String buildSfnActivityName(Class<? extends Workflow> wfClass, Class<? extends WorkflowStep> stepClass) {
+        return String.format("%s-%s", wfClass.getSimpleName(), stepClass.getSimpleName());
+    }
+
+    // package-private for testing
+    void registerActivities() {
+        try (MetricRecorder metrics = metricsFactory.newMetricRecorder("Flux.RegisterActivities")) {
+            Set<String> registeredActivities
+                    = AwsRetryUtils.executeWithInlineBackoff(this::describeRegisteredActivities, REGISTRATION_MAX_RETRY_ATTEMPTS,
+                    REGISTRATION_MIN_RETRY_DELAY, REGISTRATION_MAX_RETRY_DELAY,
+                    metrics, LIST_ACTIVITIES_METRIC_PREFIX);
+
+            for (String activityName : activitiesByName.keySet()) {
+                if (registeredActivities.contains(activityName)) {
+                    log.info("Activity {} is already registered.", activityName);
+                } else {
+                    log.info("Registering activity {}", activityName);
+
+                    CreateActivityRequest req = buildCreateActivityRequest(activityName);
+
+                    AwsRetryUtils.executeWithInlineBackoff(() -> sfn.createActivity(req),
+                            REGISTRATION_MAX_RETRY_ATTEMPTS,
+                            REGISTRATION_MIN_RETRY_DELAY, REGISTRATION_MAX_RETRY_DELAY,
+                            metrics, CREATE_ACTIVITY_METRIC_PREFIX);
+                    log.info("Successfully registered activity {}", activityName);
+                }
+            }
+        }
+    }
+
+    private Set<String> describeRegisteredActivities() {
+        ListActivitiesRequest request = ListActivitiesRequest.builder().build();
+        return sfn.listActivitiesPaginator(request).activities().stream()
+                .map(ActivityListItem::name)
+                .collect(Collectors.toSet());
+    }
+
+    static CreateActivityRequest buildCreateActivityRequest(String activityName) {
+        return CreateActivityRequest.builder()
+                .name(activityName)
+                .build();
+    }
+
+    // package-private for testing
+    void registerWorkflows() {
+        // TODO
+    }
+
+    // useless to unit-test this method, all it does is start a bunch of threads that immediately try to poll for work
+    private void initializePollers() {
+        String hostname;
+        try {
+            hostname = shortenHostnameForIdentity(InetAddress.getLocalHost().getHostName());
+        } catch (UnknownHostException e) {
+            throw new RuntimeException("Unable to determine hostname", e);
+        }
+
+        hostname = config.getHostnameTransformerForPollerIdentity().apply(hostname);
+
+        IdentifierValidation.validateHostname(hostname);
+
+        workerThreadsPerTaskList = new HashMap<>();
+        Set<String> taskLists = workflowsByClass.values().stream().map(Workflow::taskList).collect(Collectors.toSet());
+        for (String taskList : taskLists) {
+            int poolSize = config.getTaskListConfig(taskList).getActivityTaskThreadCount();
+            String poolName = String.format("worker-%s", taskList);
+            workerThreadsPerTaskList.put(taskList, new BlockOnSubmissionThreadPoolExecutor(poolSize, poolName));
+        }
+
+        activityTaskPollerThreadsPerActivity = new HashMap<>();
+        for (Map.Entry<String, WorkflowStep> entry : activitiesByName.entrySet()) {
+            Workflow workflow = workflowsByActivityName.get(entry.getKey());
+            WorkflowStep step = entry.getValue();
+            String activityArn = SfnArnFormatter.activityArn(config.getAwsRegion(), config.getAwsAccountId(),
+                                                             workflow.getClass(), step.getClass());
+            ScheduledExecutorService service = createActivityPollerPool(entry.getKey(), hostname,
+                    config.getTaskListConfig(workflow.taskList()).getActivityPollerThreadCount(),
+                    workerName -> new ActivityTaskPoller(metricsFactory, sfn, workerName, activityArn,
+                            workflow, step, workerThreadsPerTaskList.get(workflow.taskList())));
+            activityTaskPollerThreadsPerActivity.put(entry.getKey(), service);
+        }
+    }
+
+    /**
+     * Creates a worker pool.
+     *
+     * @param activityName - The name of the activity this pool should poll for.
+     * @param hostname     - The hostname of this worker.
+     * @param poolSize     - The size of the pool
+     * @param taskCreator  - A lambda that takes the full worker name as input and returns a new worker task to add to the pool.
+     */
+    private ScheduledExecutorService createActivityPollerPool(String activityName, String hostname, int poolSize,
+                                                              Function<String, Runnable> taskCreator) {
+        String poolName = String.format("poller-%s", activityName);
+        ThreadFactory threadFactory = ThreadUtils.createStackTraceSuppressingThreadFactory(poolName);
+        ScheduledExecutorService service = Executors.newScheduledThreadPool(poolSize, threadFactory);
+        for (int i = 0; i < poolSize; i++) {
+            // Since activity pollers are per-activity, the activity ARN is in the GetActivityTask request already.
+            // So all we need to do is put the hostname and the thread number in the identity.
+            String taskName = String.format("%s_%s", hostname, i);
+            Runnable task = taskCreator.apply(taskName);
+            // Scheduling the pollers so they will be restarted as soon as they end.
+            service.scheduleWithFixedDelay(ThreadUtils.wrapInExceptionSwallower(task), 0, 10, TimeUnit.MILLISECONDS);
+        }
+        return service;
+    }
+
+    /**
+     * Worker identity strings can't be too long so this method will trim out ".ec2.amazonaws.com" and similar.
+     * Additional hostname transformations can be injected by setting
+     * FluxCapacitorConfig's hostnameTransformerForPollerIdentity.
+     *
+     * Package-private for testing purposes.
+     *
+     * @param hostname The hostname to shorten
+     * @return The shortened hostname
+     */
+    static String shortenHostnameForIdentity(String hostname) {
+        String result = hostname.replace(".ec2.amazonaws.com.cn", "");
+        result = result.replace(".ec2.amazonaws.com", "");
+        result = result.replace(".compute.amazonaws.com.cn", "");
+        result = result.replace(".compute.amazonaws.com", "");
+        result = result.replace(".compute.internal", "");
+        return result;
+    }
+
+    private void startPeriodicWorkflows() {
+        periodicWorkflowScheduler = Executors.newScheduledThreadPool(1);
+        // TODO
     }
 }

--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/IdentifierValidation.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/IdentifierValidation.java
@@ -40,7 +40,7 @@ import com.danielgmyers.flux.wf.Workflow;
  * When polling for work, we use the current host's hostname as part of the poller's identity, along with a Flux-specified
  * small integer (between 0 and the poller thread pool size). While we could include the activity name in the poller identity,
  * polling is explicitly per-activity anyway so there's not much value in that. The poller thread pool should be only a few threads
- * since we don't need to poll with as many threads as we have active workers, but if we pessimistically reserve four characters
+ * since we don't need to poll with as many threads as we have active workers, but if we pessimistically reserve three characters
  * for a separator and the thread number, that leaves 77 characters for the hostname.
  *
  * Note also that we allow the user to provide a "hostname transformer" callback; this length restriction should be enforced _after_
@@ -63,7 +63,7 @@ import com.danielgmyers.flux.wf.Workflow;
  * * Workflow execution ID: 80
  * * Partition ID: 256
  *
- * These fields will also validate the content of the string against SWF's list of allowed characters:
+ * These fields will also validate the content of the string against Step Functions' list of allowed characters:
  * * Workflow class implementation name
  * * WorkflowStep class implementation name
  * * Workflow execution ID

--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/TaskListConfig.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/TaskListConfig.java
@@ -1,0 +1,61 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn;
+
+/**
+ * Container for task-list-specific configuration data used by Flux at runtime.
+ */
+public class TaskListConfig {
+
+    // Visible for testing
+    static final int DEFAULT_ACTIVITY_TASK_THREAD_COUNT = 20;
+    static final int DEFAULT_ACTIVITY_POLLER_THREAD_COUNT = 1;
+
+    private int activityTaskThreadCount = DEFAULT_ACTIVITY_TASK_THREAD_COUNT;
+    private int activityPollerThreadCount = DEFAULT_ACTIVITY_POLLER_THREAD_COUNT;
+
+    public int getActivityTaskThreadCount() {
+        return activityTaskThreadCount;
+    }
+
+    /**
+     * Sets the number of threads available to execute activity tasks. This thread pool is shared by all activities across
+     * all workflows that use this same task list.
+     *
+     * If no specific activity task thread count is provided, the default task thread count of DEFAULT_ACTIVITY_TASK_THREAD_COUNT
+     * will be used.
+     */
+    public void setActivityTaskThreadCount(int count) {
+        this.activityTaskThreadCount = count;
+    }
+
+    public int getActivityPollerThreadCount() {
+        return activityPollerThreadCount;
+    }
+
+    /**
+     * Sets the number of threads used to poll for work for each activity assigned to this task list.
+     * For a Workflow with five WorkflowSteps, this will result in 5*count polling threads. Since polling is per activity,
+     * it is recommended to keep this value small.
+     *
+     * If no specific activity poller thread count is provided, the default poller thread count of
+     * DEFAULT_ACTIVITY_POLLER_THREAD_COUNT will be used.
+     */
+    public void setActivityPollerThreadCount(int count) {
+        this.activityPollerThreadCount = count;
+    }
+}

--- a/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/poller/ActivityTaskPoller.java
+++ b/flux-sfn/src/main/java/com/danielgmyers/flux/clients/sfn/poller/ActivityTaskPoller.java
@@ -89,8 +89,8 @@ public class ActivityTaskPoller implements Runnable {
         this.metricsFactory = metricsFactory;
         this.sfn = sfnClient;
 
-        if (identity == null || identity.isEmpty() || identity.length() > 256) {
-            throw new IllegalArgumentException("Invalid identity for task poller, must be 1-256 characters: " + identity);
+        if (identity == null || identity.isEmpty() || identity.length() > 80) {
+            throw new IllegalArgumentException("Invalid identity for task poller, must be 1-80 characters: " + identity);
         }
         this.identity = identity;
 

--- a/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/FluxCapacitorTest.java
+++ b/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/FluxCapacitorTest.java
@@ -1,0 +1,386 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.danielgmyers.flux.RemoteWorkflowExecutor;
+import com.danielgmyers.flux.ex.FluxException;
+import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.StepApply;
+import com.danielgmyers.flux.step.WorkflowStep;
+import com.danielgmyers.flux.wf.Workflow;
+import com.danielgmyers.flux.wf.graph.WorkflowGraph;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphBuilder;
+import com.danielgmyers.flux.wf.graph.WorkflowGraphNode;
+import com.danielgmyers.metrics.recorders.NoopMetricRecorderFactory;
+import org.easymock.EasyMock;
+import org.easymock.IArgumentMatcher;
+import org.easymock.IMocksControl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.services.sfn.SfnClient;
+import software.amazon.awssdk.services.sfn.model.ActivityListItem;
+import software.amazon.awssdk.services.sfn.model.CreateActivityRequest;
+import software.amazon.awssdk.services.sfn.model.CreateActivityResponse;
+import software.amazon.awssdk.services.sfn.model.ListActivitiesRequest;
+import software.amazon.awssdk.services.sfn.model.ListActivitiesResponse;
+import software.amazon.awssdk.services.sfn.paginators.ListActivitiesIterable;
+
+public class FluxCapacitorTest {
+
+    private IMocksControl mockery;
+    private SfnClient sfn;
+
+    private TestWorkflow workflow;
+    private AnotherWorkflow anotherWorkflow;
+    private List<Workflow> allWorkflows;
+    private FluxCapacitorImpl fc;
+    private FluxCapacitorConfig config;
+
+    @BeforeEach
+    public void setup() {
+        workflow = new TestWorkflow();
+        anotherWorkflow = new AnotherWorkflow();
+        allWorkflows = List.of(workflow, anotherWorkflow);
+
+        mockery = EasyMock.createControl();
+        sfn = mockery.createMock(SfnClient.class);
+
+        config  = new FluxCapacitorConfig();
+        config.setAwsAccountId("123456789012");
+
+        fc = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), sfn, config, Clock.systemUTC());
+    }
+
+    @Test
+    public void getRemoteWorkflowExecutor() {
+        RemoteSfnClientConfig rcc = new RemoteSfnClientConfig();
+        rcc.setAwsRegion("us-east-2");
+
+        config.setRemoteSfnClientConfigProvider((endpointId) -> rcc);
+
+        RemoteWorkflowExecutor rwe = fc.getRemoteWorkflowExecutor("some-endpoint");
+        Assertions.assertNotNull(rwe);
+        Assertions.assertEquals(RemoteWorkflowExecutorImpl.class, rwe.getClass());
+    }
+
+    @Test
+    public void getRemoteWorkflowExecutorThrowsIfNoProviderConfigured() {
+        config.setRemoteSfnClientConfigProvider(null);
+
+        Assertions.assertThrows(IllegalStateException.class, () -> fc.getRemoteWorkflowExecutor("some-endpoint"));
+    }
+
+    @Test
+    public void getRemoteWorkflowExecutorThrowsIfProviderProvidesNullConfig() {
+        config.setRemoteSfnClientConfigProvider((endpointId) -> {
+            if (endpointId.equals("some-endpoint")) {
+                RemoteSfnClientConfig rcc = new RemoteSfnClientConfig();
+                rcc.setAwsRegion("us-east-2");
+                return rcc;
+            }
+            return null;
+        });
+
+        RemoteWorkflowExecutor rwe = fc.getRemoteWorkflowExecutor("some-endpoint");
+        Assertions.assertNotNull(rwe);
+        Assertions.assertEquals(RemoteWorkflowExecutorImpl.class, rwe.getClass());
+
+        Assertions.assertThrows(IllegalStateException.class, () -> fc.getRemoteWorkflowExecutor("fake-endpoint"));
+    }
+
+    @Test
+    public void testBuildSfnActivityName() {
+        Assertions.assertEquals("TestWorkflow-StepOne", fc.buildSfnActivityName(TestWorkflow.class, StepOne.class));
+    }
+
+    @Test
+    public void populateMapsPopulatesMaps() {
+        fc.populateMaps(allWorkflows);
+        Assertions.assertEquals(2, fc.getWorkflowsByClass().size());
+        Assertions.assertEquals(workflow, fc.getWorkflowsByClass().get(TestWorkflow.class));
+        Assertions.assertEquals(anotherWorkflow, fc.getWorkflowsByClass().get(AnotherWorkflow.class));
+
+        Assertions.assertEquals(5, fc.getActivitiesByName().size());
+        Assertions.assertEquals(workflow.stepOne, fc.getActivitiesByName().get(fc.buildSfnActivityName(TestWorkflow.class, StepOne.class)));
+        Assertions.assertEquals(workflow.stepTwo, fc.getActivitiesByName().get(fc.buildSfnActivityName(TestWorkflow.class, StepTwo.class)));
+        Assertions.assertEquals(anotherWorkflow.stepOne, fc.getActivitiesByName().get(fc.buildSfnActivityName(AnotherWorkflow.class, StepOne.class)));
+        Assertions.assertEquals(anotherWorkflow.stepTwo, fc.getActivitiesByName().get(fc.buildSfnActivityName(AnotherWorkflow.class, StepTwo.class)));
+        Assertions.assertEquals(anotherWorkflow.stepThree, fc.getActivitiesByName().get(fc.buildSfnActivityName(AnotherWorkflow.class, StepThree.class)));
+
+        Assertions.assertEquals(5, fc.getWorkflowsByActivityName().size());
+        Assertions.assertEquals(workflow, fc.getWorkflowsByActivityName().get(fc.buildSfnActivityName(TestWorkflow.class, StepOne.class)));
+        Assertions.assertEquals(workflow, fc.getWorkflowsByActivityName().get(fc.buildSfnActivityName(TestWorkflow.class, StepTwo.class)));
+        Assertions.assertEquals(anotherWorkflow, fc.getWorkflowsByActivityName().get(fc.buildSfnActivityName(AnotherWorkflow.class, StepOne.class)));
+        Assertions.assertEquals(anotherWorkflow, fc.getWorkflowsByActivityName().get(fc.buildSfnActivityName(AnotherWorkflow.class, StepTwo.class)));
+        Assertions.assertEquals(anotherWorkflow, fc.getWorkflowsByActivityName().get(fc.buildSfnActivityName(AnotherWorkflow.class, StepThree.class)));
+    }
+
+    // Minor naming gymnastics so we can put two workflow steps with the same class name into a workflow graph,
+    // or define two different workflow classes with the same class name. This isn't actually allowed, so
+    // we're doing it to ensure the relevant test fails.
+    static class ContainerClass {
+        static class TestWorkflow implements Workflow {
+            private final WorkflowGraph graph;
+
+            TestWorkflow() {
+                StepOne stepOne = new StepOne();
+                WorkflowGraphBuilder builder = new WorkflowGraphBuilder(stepOne);
+                builder.alwaysClose(stepOne);
+                this.graph = builder.build();
+            }
+
+            @Override
+            public WorkflowGraph getGraph() {
+                return graph;
+            }
+        }
+
+        static class StepOne implements WorkflowStep {
+            @StepApply
+            public void doThing() {}
+        }
+    }
+
+    @Test
+    public void populateMapsDetectsWorkflowNameCollision() {
+        Workflow wf1 = new TestWorkflow();
+        Workflow wf2 = new ContainerClass.TestWorkflow();
+
+        // make sure the test fails if someone accidentally renames one of those workflows
+        Assertions.assertEquals(wf1.getClass().getSimpleName(), wf2.getClass().getSimpleName());
+
+        try {
+            fc.populateMaps(List.of(wf1, wf2));
+            Assertions.fail("Should not be allowed to register two workflows with the same class name");
+        } catch (FluxException e) {
+            Assertions.assertTrue(e.getMessage().contains(TaskNaming.workflowName(wf1)));
+        }
+    }
+
+    static class WorkflowWithActivityNameCollision implements Workflow {
+        private final WorkflowGraph graph;
+
+        WorkflowWithActivityNameCollision() {
+            StepOne outerStepOne = new StepOne();
+            ContainerClass.StepOne innerStepOne = new ContainerClass.StepOne();
+
+            WorkflowGraphBuilder builder = new WorkflowGraphBuilder(outerStepOne);
+            builder.alwaysTransition(outerStepOne, innerStepOne);
+
+            builder.addStep(innerStepOne);
+            builder.alwaysClose(innerStepOne);
+
+            this.graph = builder.build();
+        }
+
+        @Override
+        public WorkflowGraph getGraph() {
+            return graph;
+        }
+    }
+
+    @Test
+    public void populateMapsDetectsActivityNameCollision() {
+        Workflow wf = new WorkflowWithActivityNameCollision();
+
+        try {
+            fc.populateMaps(Collections.singletonList(wf));
+            Assertions.fail("Should not be allowed to register a workflow with two steps having the same class name");
+        } catch (FluxException e) {
+            Assertions.assertTrue(e.getMessage().contains(StepOne.class.getSimpleName()));
+        }
+    }
+
+    @Test
+    public void registersActivitiesIfNotAlreadyRegistered() {
+        fc.populateMaps(allWorkflows);
+
+        expectDescribeActivities(false);
+
+        for (Workflow w : allWorkflows) {
+            for (WorkflowGraphNode node : w.getGraph().getNodes().values()) {
+                String activityName = fc.buildSfnActivityName(w.getClass(), node.getStep().getClass());
+                CreateActivityRequest register = FluxCapacitorImpl.buildCreateActivityRequest(activityName);
+
+                EasyMock.expect(sfn.createActivity(register)).andReturn(CreateActivityResponse.builder().build());
+            }
+        }
+
+        mockery.replay();
+        fc.registerActivities();
+        mockery.verify();
+    }
+
+    @Test
+    public void registersActivitiesIfNotAlreadyRegistered_HandlesThrottling() {
+        fc.populateMaps(allWorkflows);
+
+        expectDescribeActivities(false);
+
+        for (Workflow w : allWorkflows) {
+            for (WorkflowGraphNode node : w.getGraph().getNodes().values()) {
+                String activityName = fc.buildSfnActivityName(w.getClass(), node.getStep().getClass());
+                CreateActivityRequest register = FluxCapacitorImpl.buildCreateActivityRequest(activityName);
+
+                EasyMock.expect(sfn.createActivity(register)).andThrow(SdkServiceException.builder().statusCode(429).build());
+                EasyMock.expect(sfn.createActivity(register)).andReturn(CreateActivityResponse.builder().build());
+            }
+        }
+
+        mockery.replay();
+        fc.registerActivities();
+        mockery.verify();
+    }
+
+    @Test
+    public void doesNotRegisterActivitiesIfAlreadyRegistered() {
+        fc.populateMaps(allWorkflows);
+
+        expectDescribeActivities(true);
+
+        mockery.replay();
+        fc.registerActivities();
+        mockery.verify();
+    }
+
+    @Test
+    public void testHostnameShortener() {
+        String base = "ec2-123-45-67-89.us-west-2";
+        Assertions.assertEquals(base, FluxCapacitorImpl.shortenHostnameForIdentity(base + ".ec2.amazonaws.com"));
+        Assertions.assertEquals(base, FluxCapacitorImpl.shortenHostnameForIdentity(base + ".ec2.amazonaws.com.cn"));
+        Assertions.assertEquals(base, FluxCapacitorImpl.shortenHostnameForIdentity(base + ".compute.amazonaws.com"));
+        Assertions.assertEquals(base, FluxCapacitorImpl.shortenHostnameForIdentity(base + ".compute.amazonaws.com.cn"));
+        Assertions.assertEquals(base, FluxCapacitorImpl.shortenHostnameForIdentity(base + ".compute.internal"));
+    }
+
+    static <T extends SdkPojo> T sdkFieldMatcher(T request) {
+        EasyMock.reportMatcher(new IArgumentMatcher() {
+            @Override
+            public boolean matches(Object o) {
+                return request.equalsBySdkFields(o);
+            }
+
+            @Override
+            public void appendTo(StringBuffer stringBuffer) {
+                stringBuffer.append("request{");
+                stringBuffer.append(request);
+                stringBuffer.append("}");
+            }
+        });
+        return request;
+    }
+
+    private void expectDescribeActivities(boolean shouldExist) {
+        ListActivitiesResponse response;
+        if(shouldExist) {
+            List<ActivityListItem> activities = new ArrayList<>();
+            for (Workflow w : allWorkflows) {
+                for (WorkflowGraphNode node : w.getGraph().getNodes().values()) {
+                    String activityName = fc.buildSfnActivityName(w.getClass(), node.getStep().getClass());
+                    ActivityListItem item = ActivityListItem.builder().name(activityName).build();
+                    activities.add(item);
+                }
+            }
+            response = ListActivitiesResponse.builder().activities(activities).build();
+        } else {
+            response = ListActivitiesResponse.builder().activities(Collections.emptyList()).build();
+        }
+
+        ListActivitiesRequest request = ListActivitiesRequest.builder().build();
+        EasyMock.expect(sfn.listActivities(sdkFieldMatcher(request))).andReturn(response); // called internally by the iterable
+        EasyMock.expect(sfn.listActivitiesPaginator(request)).andReturn(new ListActivitiesIterable(sfn, request));
+    }
+
+    public static class TestWorkflow implements Workflow {
+        final WorkflowStep stepOne;
+        final WorkflowStep stepTwo;
+
+        private final WorkflowGraph graph;
+
+        TestWorkflow() {
+            stepOne = new StepOne();
+            stepTwo = new StepTwo();
+
+            WorkflowGraphBuilder builder = new WorkflowGraphBuilder(stepOne);
+            builder.alwaysTransition(stepOne, stepTwo);
+
+            builder.addStep(stepTwo);
+            builder.alwaysClose(stepTwo);
+
+            this.graph = builder.build();
+        }
+
+        @Override
+        public WorkflowGraph getGraph() {
+            return graph;
+        }
+    }
+
+    public static class AnotherWorkflow implements Workflow {
+        final WorkflowStep stepOne;
+        final WorkflowStep stepTwo;
+        final WorkflowStep stepThree;
+
+        private final WorkflowGraph graph;
+
+        AnotherWorkflow() {
+            stepOne = new StepOne();
+            stepTwo = new StepTwo();
+            stepThree = new StepThree();
+
+            WorkflowGraphBuilder builder = new WorkflowGraphBuilder(stepOne);
+            builder.alwaysTransition(stepOne, stepTwo);
+
+            builder.addStep(stepTwo);
+            builder.alwaysTransition(stepTwo, stepThree);
+
+            builder.addStep(stepThree);
+            builder.alwaysClose(stepThree);
+
+            this.graph = builder.build();
+        }
+
+        @Override
+        public WorkflowGraph getGraph() {
+            return graph;
+        }
+    }
+
+    public static class StepOne implements WorkflowStep {
+        @StepApply
+        public void doThing() {}
+    }
+
+    public static class StepTwo implements WorkflowStep {
+        @StepApply
+        public void doThing() {}
+    }
+
+    public static class StepThree implements WorkflowStep {
+        @StepApply
+        public void doThing() {}
+    }
+}

--- a/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/TaskListConfigTest.java
+++ b/flux-sfn/src/test/java/com/danielgmyers/flux/clients/sfn/TaskListConfigTest.java
@@ -1,0 +1,40 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.clients.sfn;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TaskListConfigTest {
+
+    @Test
+    public void defaultConfigValues() {
+        TaskListConfig config = new TaskListConfig();
+        Assertions.assertEquals(TaskListConfig.DEFAULT_ACTIVITY_TASK_THREAD_COUNT, config.getActivityTaskThreadCount());
+        Assertions.assertEquals(TaskListConfig.DEFAULT_ACTIVITY_POLLER_THREAD_COUNT, config.getActivityPollerThreadCount());
+    }
+
+    @Test
+    public void allowCustomValues() {
+        TaskListConfig config = new TaskListConfig();
+        config.setActivityTaskThreadCount(134);
+        config.setActivityPollerThreadCount(42);
+
+        Assertions.assertEquals(134, config.getActivityTaskThreadCount());
+        Assertions.assertEquals(42, config.getActivityPollerThreadCount());
+    }
+}


### PR DESCRIPTION
These pieces are now implemented:
* Activity registration on initialization
* Activity poller and worker thread pool creation on initialization
* Unit tests for getRemoteWorkflowExecutor
* shutdown
* awaitTermination

https://github.com/danielgmyers/flux-swf-client/issues/120
