### PR TITLE
Migrating to Sonatype's Central Portal from their Legacy OSSRH

### DIFF
--- a/buildspec/build-and-publish.yml
+++ b/buildspec/build-and-publish.yml
@@ -14,11 +14,9 @@ phases:
   pre_build:
     commands:
       - mkdir -p ~/.m2/
-      - echo "<settings><servers><server><id>sonatype-nexus-staging</id>" > ~/.m2/settings.xml
+      - echo "<settings><servers><server><id>central</id>" > ~/.m2/settings.xml
       - echo "<username>${MAVEN_CENTRAL_USERNAME}</username><password>${MAVEN_CENTRAL_PASSWORD}</password>" >> ~/.m2/settings.xml
       - echo "</server></servers></settings>" >> ~/.m2/settings.xml
-      - echo "$GPG_PRIVATE_KEY" > flux-signing-key-private.gpg
-      - gpg --import --passphrase $GPG_PASSPHRASE --batch flux-signing-key-private.gpg
   build:
     commands:
-      - mvn -Dpublishing.autoReleaseAfterClose=true deploy -P release
+      - mvn -Dpublishing.publishAfterStaging=true deploy -P release

--- a/buildspec/build-and-stage.yml
+++ b/buildspec/build-and-stage.yml
@@ -14,11 +14,9 @@ phases:
   pre_build:
     commands:
       - mkdir -p ~/.m2/
-      - echo "<settings><servers><server><id>sonatype-nexus-staging</id>" > ~/.m2/settings.xml
+      - echo "<settings><servers><server><id>central</id>" > ~/.m2/settings.xml
       - echo "<username>${MAVEN_CENTRAL_USERNAME}</username><password>${MAVEN_CENTRAL_PASSWORD}</password>" >> ~/.m2/settings.xml
       - echo "</server></servers></settings>" >> ~/.m2/settings.xml
-      - echo "$GPG_PRIVATE_KEY" > flux-signing-key-private.gpg
-      - gpg --import --passphrase $GPG_PASSPHRASE --batch flux-signing-key-private.gpg
   build:
     commands:
       - mvn deploy -P release

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
         <mavenplugin.surefire.version>2.22.2</mavenplugin.surefire.version>
         <mavenplugin.source.version>3.2.1</mavenplugin.source.version>
         <mavenplugin.javadoc.version>3.4.1</mavenplugin.javadoc.version>
-        <mavenplugin.gpg.version>3.0.1</mavenplugin.gpg.version>
-        <mavenplugin.nexusstaging.version>1.6.13</mavenplugin.nexusstaging.version>
+        <mavenplugin.gpg.version>3.2.7</mavenplugin.gpg.version>
+        <mavenplugin.centralpublishing.version>0.7.0</mavenplugin.centralpublishing.version>
 
         <checkstyle.version>10.3.4</checkstyle.version>
 
@@ -191,7 +191,7 @@
             <id>release</id>
             <properties>
                 <!-- Used here to allow overriding from the command line -->
-                <publishing.autoReleaseAfterClose>false</publishing.autoReleaseAfterClose>
+                <publishing.publishAfterStaging>false</publishing.publishAfterStaging>
             </properties>
             <build>
                 <plugins>
@@ -241,25 +241,23 @@
                         </executions>
                         <configuration>
                             <skip>${skip.deploy}</skip>
-                            <keyname>${env.GPG_KEY_ID}</keyname>
-                            <passphrase>${env.GPG_PASSPHRASE}</passphrase>
-                            <gpgArguments>
-                                <arg>--batch</arg>
-                                <arg>--pinentry</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
+                            <signer>bc</signer>
+                            <keyFingerprintEnvName>GPG_KEY_ID</keyFingerprintEnvName>
+                            <keyEnvName>GPG_PRIVATE_KEY</keyEnvName>
+                            <passphraseEnvName>GPG_PASSPHRASE</passphraseEnvName>
+                            <useAgent>false</useAgent>
+                            <bestPractices>true</bestPractices>
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${mavenplugin.nexusstaging.version}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${mavenplugin.centralpublishing.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>${publishing.autoReleaseAfterClose}</autoReleaseAfterClose>
-                            <skipNexusStagingDeployMojo>${skip.deploy}</skipNexusStagingDeployMojo>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>${publishing.publishAfterStaging}</autoPublish>
+                            <skipPublishing>${skip.deploy}</skipPublishing>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
OSSRH is reaching end of life on June 30, 2025, so we need to migrate to the Central Portal. See https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/ for information on the differences between them and https://central.sonatype.org/publish/publish-portal-maven/ for the official instructions on how to publish to the central repo.

I'm also switching to the pure java bouncycastle gpg signer so we don't have to worry about gpg versions or password input gymnastics (I was having trouble getting gpg to work on my desktop without breaking how it works in CodeBuild).

I've already generated a new Central Portal auth token and put it in Secrets Manager, so the release will just work next time we need to run it.